### PR TITLE
style: Renamed unittest and fixed __init__

### DIFF
--- a/pyronear/utils/__init__.py
+++ b/pyronear/utils/__init__.py
@@ -1,1 +1,3 @@
-from .collect_env import *
+from .collect_env import get_pretty_env_info
+
+del collect_env

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,10 +1,10 @@
 import unittest
-from pyronear.utils.collect_env import get_pretty_env_info
+from pyronear import utils
 
 
 class TestCollectEnv(unittest.TestCase):
     def test_prettyenv(self):
-        info_output = get_pretty_env_info()
+        info_output = utils.get_pretty_env_info()
         self.assertTrue(info_output.count('\n') >= 19)
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,7 @@ from pyronear.utils.collect_env import get_pretty_env_info
 
 
 class TestCollectEnv(unittest.TestCase):
-    def test_smoke(self):
+    def test_prettyenv(self):
         info_output = get_pretty_env_info()
         self.assertTrue(info_output.count('\n') >= 19)
 


### PR DESCRIPTION
Renamed unittest to match the tested function's name and remove `collect_env` from `__init__` as it is not supposed to be used by the library, but as a debugging tool.