### PR TITLE
fix: Fixed OpenFire image extension guessing

### DIFF
--- a/pyronear/datasets/utils.py
+++ b/pyronear/datasets/utils.py
@@ -11,8 +11,6 @@ from urllib.parse import urlparse
 
 from torchvision.datasets.utils import check_integrity
 
-IMG_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif']
-
 
 def url_retrieve(url, outfile, timeout=4):
     """Download the content of an URL request to a specified location
@@ -44,7 +42,7 @@ def get_fname(url, default_extension='jpg', max_base_length=50):
 
     name_split = urlparse(url).path.rpartition('/')[-1].split('.')
     # Check if viable extension
-    if len(name_split) > 1 and name_split[-1].lower() in IMG_EXTENSIONS:
+    if len(name_split) > 1 and all(c.isalpha() for c in name_split[-1].lower()):
         base, extension = '.'.join(name_split[:-1]), name_split[-1].lower()
     # Fallback on default extension
     else:

--- a/pyronear/datasets/utils.py
+++ b/pyronear/datasets/utils.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 from torchvision.datasets.utils import check_integrity
 
+IMG_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif']
+
 
 def url_retrieve(url, outfile, timeout=4):
     """Download the content of an URL request to a specified location
@@ -42,8 +44,9 @@ def get_fname(url, default_extension='jpg', max_base_length=50):
 
     name_split = urlparse(url).path.rpartition('/')[-1].split('.')
     # Check if viable extension
-    if len(name_split) > 1 and 1 < len(name_split[-1]) <= 4:
+    if len(name_split) > 1 and name_split[-1].lower() in IMG_EXTENSIONS:
         base, extension = '.'.join(name_split[:-1]), name_split[-1].lower()
+    # Fallback on default extension
     else:
         base, extension = name_split[-1], default_extension
     # Check base length

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -54,6 +54,10 @@ class TestCollectEnv(unittest.TestCase):
             dataset = datasets.OpenFire(root=root, train=True, download=True)
             self.assertIsInstance(dataset, VisionDataset)
 
+            # Assert valid extensions of every image
+            self.assertTrue(all(sample['path'].rpartition('.')[-1] in datasets.utils.IMG_EXTENSIONS
+                                for sample in dataset.data))
+
             # Check against number of samples in extract
             datasets.utils.download_url(dataset.url, root, filename='extract.json', verbose=False)
             with open(root.joinpath('extract.json'), 'rb') as f:

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -55,7 +55,7 @@ class TestCollectEnv(unittest.TestCase):
             self.assertIsInstance(dataset, VisionDataset)
 
             # Assert valid extensions of every image
-            self.assertTrue(all(sample['path'].rpartition('.')[-1] in datasets.utils.IMG_EXTENSIONS
+            self.assertTrue(all(sample['path'].name.rpartition('.')[-1] in ['jpg', 'jpeg', 'png', 'gif']
                                 for sample in dataset.data))
 
             # Check against number of samples in extract


### PR DESCRIPTION
Initially, extension guessing was accepting short strings without checking if there was any digit in it for instance. Some images ended up with `.760` extensions which can be troublesome for some OS.

This PR fixes the extension guessing and adds a unittest for  ̀OpenFire` related to this issue.
See #20 