### PR TITLE
Clarify openfire validation set creation

### DIFF
--- a/pyronear/datasets/openfire.py
+++ b/pyronear/datasets/openfire.py
@@ -48,7 +48,12 @@ class OpenFire(VisionDataset):
         self.train = train  # training set or test set
 
         if download:
-            self.download(threads, valid_ratio)
+            if (not isinstance(valid_ratio, (float, type(None))) or
+                not (0 <= valid_ratio <= 1)):
+                raise ValueError(f"ratio to create Validation set should be a floating number between 0 and 1. Ratio found = {valid_ratio}")
+            else:
+                pass
+                self.download(threads, valid_ratio)
 
         if not self._check_exists(train):
             raise RuntimeError('Dataset not found.' +
@@ -150,7 +155,7 @@ class OpenFire(VisionDataset):
             warnings.warn((f'{unavailable_idxs}/{len(annotations)} samples could not be downloaded. Please retry later.'))
 
         # Override current train/test split
-        if isinstance(valid_pct, float):
+        if valid_ratio is not None:
             full_set = training_set + test_set
             # Local seed to avoid disturbing global functions
             random.Random(self.seed).shuffle(full_set)

--- a/pyronear/datasets/openfire.py
+++ b/pyronear/datasets/openfire.py
@@ -48,8 +48,7 @@ class OpenFire(VisionDataset):
         self.train = train  # training set or test set
 
         if download:
-            if (not isinstance(valid_ratio, (float, type(None))) or
-                not (0 <= valid_ratio <= 1)):
+            if isinstance(valid_ratio, (float, int)) and not (0 <= valid_ratio <= 1):
                 raise ValueError(f"ratio to create Validation set should be a floating number between 0 and 1. Ratio found = {valid_ratio}")
             else:
                 self.download(threads, valid_ratio)

--- a/pyronear/datasets/openfire.py
+++ b/pyronear/datasets/openfire.py
@@ -52,7 +52,6 @@ class OpenFire(VisionDataset):
                 not (0 <= valid_ratio <= 1)):
                 raise ValueError(f"ratio to create Validation set should be a floating number between 0 and 1. Ratio found = {valid_ratio}")
             else:
-                pass
                 self.download(threads, valid_ratio)
 
         if not self._check_exists(train):

--- a/pyronear/datasets/openfire.py
+++ b/pyronear/datasets/openfire.py
@@ -32,7 +32,7 @@ class OpenFire(VisionDataset):
             downloaded again.
         threads (int, optional): If download is set to True, use this amount of threads
             for downloading the dataset.
-        valid_pct (float, optional): Percentage of training set used for validation.
+        valid_ratio (float, optional): Ratio of dataset used for validation. Should be between 0 and 1.
     """
 
     url = 'https://gist.githubusercontent.com/frgfm/f53b4f53a1b2dc3bb4f18c006a32ec0d/raw/99e5be2afd957b2da841f0adf8c5dfa47fe57166/openfire_binary.json'
@@ -42,13 +42,13 @@ class OpenFire(VisionDataset):
     seed = 42
 
     def __init__(self, root, train=True, transform=None, target_transform=None,
-                 download=False, threads=16, valid_pct=None):
+                 download=False, threads=16, valid_ratio=None):
         super(OpenFire, self).__init__(root, transform=transform,
                                     target_transform=target_transform)
         self.train = train  # training set or test set
 
         if download:
-            self.download(threads, valid_pct)
+            self.download(threads, valid_ratio)
 
         if not self._check_exists(train):
             raise RuntimeError('Dataset not found.' +
@@ -101,12 +101,12 @@ class OpenFire(VisionDataset):
         else:
             return self._root.joinpath(self._processed, self.test_file).is_file()
 
-    def download(self, threads=None, valid_pct=None):
+    def download(self, threads=None, valid_ratio=None):
         """Download the OpenFire data if it doesn't exist in processed_folder already.
 
         Args:
             threads (int, optional): Number of threads to use for dataset downloading.
-            valid_pct (float, optional): Percentage of training set used for validation.
+            valid_ratio (float, optional): Ratio of dataset used for validation. Should be between 0 and 1.
         """
 
         if self._check_exists(train=True) and self._check_exists(train=False):
@@ -154,7 +154,7 @@ class OpenFire(VisionDataset):
             full_set = training_set + test_set
             # Local seed to avoid disturbing global functions
             random.Random(self.seed).shuffle(full_set)
-            valid_size = int(valid_pct * len(full_set))
+            valid_size = int(valid_ratio * len(full_set))
             training_set, test_set = full_set[:-valid_size], full_set[-valid_size:]
 
         # save as torch files

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -84,7 +84,7 @@ class TestCollectEnv(unittest.TestCase):
 
         with Path(tempfile.TemporaryDirectory().name) as root:
 
-            incorrect_valid_ratios = [-25, -0.01, 1.01, 15, True, list()]
+            incorrect_valid_ratios = [-25, -0.01, 1.01, 15]
 
             for incorrect_valid_ratio in incorrect_valid_ratios:
                 with self.assertRaises(ValueError):

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -79,6 +79,17 @@ class TestCollectEnv(unittest.TestCase):
             train_paths = [sample['path'] for sample in train_set.data]
             self.assertTrue(all(sample['path'] not in train_paths for sample in test_set.data))
 
+    def test_openfire_validation(self):
+        """Check if Exception is raised when providing incorrect split ratio for validation"""
+
+        with Path(tempfile.TemporaryDirectory().name) as root:
+
+            incorrect_valid_ratios = [-25, -0.01, 1.01, 15, True, list()]
+
+            for incorrect_valid_ratio in incorrect_valid_ratios:
+                with self.assertRaises(ValueError):
+                    datasets.OpenFire(root=root, train=True, download=True, valid_ratio=incorrect_valid_ratio)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -47,7 +47,7 @@ class TestCollectEnv(unittest.TestCase):
         with Path(tempfile.TemporaryDirectory().name) as root:
 
             # Warning for missing train/test split
-            self.assertWarns(UserWarning, datasets.OpenFire, root=root, download=True, valid_pct=None)
+            self.assertWarns(UserWarning, datasets.OpenFire, root=root, download=True, valid_ratio=None)
 
             # Working case
             # Check inherited properties
@@ -72,8 +72,8 @@ class TestCollectEnv(unittest.TestCase):
             self.assertEqual(dataset.class_to_idx[extract[0]['target']], target)
 
             # Check train/test split
-            train_set = datasets.OpenFire(root=root, train=True, download=True, valid_pct=0.2)
-            test_set = datasets.OpenFire(root=root, train=False, download=True, valid_pct=0.2)
+            train_set = datasets.OpenFire(root=root, train=True, download=True, valid_ratio=0.2)
+            test_set = datasets.OpenFire(root=root, train=False, download=True, valid_ratio=0.2)
             self.assertIsInstance(train_set, VisionDataset)
             # Check unicity of sample across all splits
             train_paths = [sample['path'] for sample in train_set.data]


### PR DESCRIPTION
This PR aims at:
- clarifying the name to set validation ratio (between 0 and 1) instead of percentage (between 0 and 100)
- raising exception when this ratio is not within correct range. Before, it was possible to set wrong number (ie: setting 21.5 instead of 0.215 would not raise any warning nor exception)

Any feedback is welcome,
cheers
