### PR TITLE
fix: Fixed training scripts

### DIFF
--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -50,6 +50,8 @@ def main(args):
                                  ps=args.dropout_prob,
                                  concat_pool=args.concat_pool,
                                  metrics=vision.error_rate)
+    if args.resume:
+        learner.load(args.resume)
     if args.unfreeze:
         learner.unfreeze()
 
@@ -81,6 +83,7 @@ if __name__ == "__main__":
                         dest='weight_decay')
     parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
+    parser.add_argument('--resume', default=None, help='resume from checkpoint')
     parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
                         action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -40,21 +40,21 @@ def main(args):
 
     df = pd.DataFrame.from_dict(dict(name=fnames, label=labels, is_valid=is_valid))
 
-
     il = vision.ImageList.from_df(df, path=args.data_path).split_from_df('is_valid').label_from_df(cols='label')
-    data = il.transform(vision.get_transforms(), size=args.resize).databunch(bs=args.batch_size, num_workers=args.workers).normalize(vision.imagenet_stats)
+    il = il.transform(vision.get_transforms(), size=args.resize)
+    data = il.databunch(bs=args.batch_size, num_workers=args.workers).normalize(vision.imagenet_stats)
 
     learner = vision.cnn_learner(data, vision.models.__dict__[args.model],
-                               pretrained=args.pretrained,
-                               wd=args.weight_decay,
-                               ps=args.dropout_prob,
-                               concat_pool=args.concat_pool,
-                               metrics=vision.error_rate)
+                                 pretrained=args.pretrained,
+                                 wd=args.weight_decay,
+                                 ps=args.dropout_prob,
+                                 concat_pool=args.concat_pool,
+                                 metrics=vision.error_rate)
     if args.unfreeze:
         learner.unfreeze()
 
     learner.fit_one_cycle(args.epochs, max_lr=slice(None, args.lr, None),
-                        div_factor=args.div_factor)
+                          div_factor=args.div_factor)
 
     learner.save(args.checkpoint)
 

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
                         dest='weight_decay')
     parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
-    parser.add_argument('--resume', default=None, help='resume from checkpoint')
+    parser.add_argument('--resume', default=None, help='checkpoint name to resume from (default: None)')
     parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
                         action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -50,6 +50,8 @@ def main(args):
                                ps=args.dropout_prob,
                                concat_pool=args.concat_pool,
                                metrics=vision.error_rate)
+    if args.unfreeze:
+        learner.unfreeze()
 
     learner.fit_one_cycle(args.epochs, max_lr=slice(None, args.lr, None),
                         div_factor=args.div_factor)
@@ -71,21 +73,19 @@ if __name__ == "__main__":
                         help='number of data loading workers (default: 16)')
     parser.add_argument('--lr', default=3e-3, type=float, help='initial learning rate')
     parser.add_argument("--concat-pool", dest="concat_pool",
-        help="Use pre-trained models from the modelzoo",
-        action="store_true"
-    )
+                        help="Use pre-trained models from the modelzoo",
+                        action="store_true")
     parser.add_argument('--dropout-prob', default=0.5, type=float, help='dropout rate of last FC layer')
     parser.add_argument('--wd', '--weight-decay', default=1e-2, type=float,
                         metavar='W', help='weight decay (default: 1e-2)',
                         dest='weight_decay')
     parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
-    parser.add_argument(
-        "--pretrained",
-        dest="pretrained",
-        help="Use pre-trained models from the modelzoo",
-        action="store_true",
-    )
+    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
+                        action="store_true")
+    parser.add_argument("--pretrained", dest="pretrained",
+                        help="Use pre-trained models from the modelzoo",
+                        action="store_true")
     args = parser.parse_args()
 
     main(args)

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -284,13 +284,11 @@ if __name__ == "__main__":
     parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
                         action="store_true")
     parser.add_argument("--deterministic", dest="deterministic",
-        help="Should the training be performed in deterministic mode",
-        action="store_true",
-    )
+                        help="Should the training be performed in deterministic mode",
+                        action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",
-        help="Use pre-trained models from the modelzoo",
-        action="store_true",
-    )
+                        help="Use pre-trained models from the modelzoo",
+                        action="store_true")
     args = parser.parse_args()
 
     main(args)

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -178,6 +178,10 @@ def main(args):
     in_features = getattr(model, 'fc').in_features
     setattr(model, 'fc', nn.Linear(in_features, num_classes))
 
+    # Resume
+    if args.resume:
+        model.load_state_dict(torch.load(args.resume)['model'])
+
     # Freeze layers
     if not args.unfreeze:
         # Model is sequential
@@ -252,7 +256,7 @@ if __name__ == "__main__":
     parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
     parser.add_argument('--output-dir', default=None, help='path where to save')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
-    parser.add_argument('--resume', default='', help='resume from checkpoint')
+    parser.add_argument('--resume', default=None, help='resume from checkpoint')
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
                         help='start epoch')
     parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -41,9 +41,10 @@ def train_batch(model, x, target, optimizer, criterion):
     """Train a model for one iteration
     Args:
         model (torch.nn.Module): model to train
-        loader_iter (iter(torch.utils.data.DataLoader)): training dataloader iterator
+        x (torch.Tensor): input sample
+        target (torch.Tensor): output target
         optimizer (torch.optim.Optimizer): parameter optimizer
-        criterion (torch.nn.Module): criterion object
+        criterion (torch.nn.Module): loss used for backpropagation
     Returns:
         batch_loss (float): training loss
     """
@@ -104,7 +105,7 @@ def evaluate(model, test_loader, criterion, device='cpu'):
     """Evaluation a model on a dataloader
     Args:
         model (torch.nn.Module): model to train
-        train_loader (torch.utils.data.DataLoader): validation dataloader
+        test_loader (torch.utils.data.DataLoader): validation dataloader
         criterion (torch.nn.Module): criterion object
         device (str): device hosting tensor data
     Returns:

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -243,7 +243,6 @@ def main(args):
 
         # State saving
         if val_loss < best_loss:
-            best_loss = val_loss
             if args.output_dir:
                 print(f"Validation loss decreased {best_loss:.4} --> {val_loss:.4}: saving state...")
                 torch.save(dict(model=model.state_dict(),
@@ -252,6 +251,7 @@ def main(args):
                                 epoch=epoch_idx,
                                 args=args),
                            Path(args.output_dir, f"{args.checkpoint}.pth"))
+            best_loss = val_loss
 
 
 if __name__ == "__main__":

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -173,9 +173,9 @@ def main(args):
 
     # Data loader
     train_loader = torch.utils.data.DataLoader(train_set, batch_size=args.batch_size, sampler=train_sampler,
-                                             num_workers=args.workers, pin_memory=True)
+                                               num_workers=args.workers, pin_memory=True)
     test_loader = torch.utils.data.DataLoader(val_set, batch_size=args.batch_size, sampler=test_sampler,
-                                            num_workers=args.workers, pin_memory=True)
+                                              num_workers=args.workers, pin_memory=True)
 
     # Model definition
     model = torchvision.models.__dict__[args.model](pretrained=args.pretrained)
@@ -204,9 +204,9 @@ def main(args):
 
     # Scheduler
     lr_scheduler = optim.lr_scheduler.OneCycleLR(optimizer, max_lr=args.lr,
-                                              epochs=args.epochs, steps_per_epoch=len(train_loader),
-                                              cycle_momentum=(not isinstance(optimizer, optim.Adam)),
-                                              div_factor=args.div_factor, final_div_factor=args.final_div_factor)
+                                                 epochs=args.epochs, steps_per_epoch=len(train_loader),
+                                                 cycle_momentum=(not isinstance(optimizer, optim.Adam)),
+                                                 div_factor=args.div_factor, final_div_factor=args.final_div_factor)
 
     best_loss = math.inf
     mb = master_bar(range(args.epochs))
@@ -220,7 +220,8 @@ def main(args):
         val_loss, acc = evaluate(model, test_loader, criterion, device=args.device)
 
         mb.first_bar.comment = f"Epoch {epoch_idx+1}/{args.epochs}"
-        mb.write(f'Epoch {epoch_idx+1}/{args.epochs} - Training loss: {train_loss:.4} | Validation loss: {val_loss:.4} | Error rate: {1 - acc:.4}')
+        mb.write(f"Epoch {epoch_idx+1}/{args.epochs} - Training loss: {train_loss:.4} | "
+                 f"Validation loss: {val_loss:.4} | Error rate: {1 - acc:.4}")
 
         # State saving
         if val_loss < best_loss:

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -147,7 +147,7 @@ def main(args):
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                      std=[0.229, 0.224, 0.225])
 
-    train_transforms = transforms.Compose([
+    data_transforms = transforms.Compose([
         transforms.RandomResizedCrop((args.resize, args.resize)),
         transforms.RandomHorizontalFlip(),
         transforms.RandomRotation(10),
@@ -155,17 +155,11 @@ def main(args):
         normalize
     ])
 
-    test_transforms = transforms.Compose([
-        transforms.Resize((args.resize, args.resize)),
-        transforms.ToTensor(),
-        normalize
-    ])
-
     # Train & test sets
     train_set = OpenFire(root=args.data_path, train=True, download=True, valid_pct=0.2,
-                         transform=train_transforms)
+                         transform=data_transforms)
     val_set = OpenFire(root=args.data_path, train=False, download=True, valid_pct=0.2,
-                       transform=test_transforms)
+                       transform=data_transforms)
     num_classes = len(train_set.classes)
     # Samplers
     train_sampler = torch.utils.data.RandomSampler(train_set)

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -223,9 +223,9 @@ def main(args):
 
         # State saving
         if val_loss < best_loss:
-            print(f"Validation loss decreased {best_loss:.4} --> {val_loss:.4}: saving state...")
             best_loss = val_loss
             if args.output_dir:
+                print(f"Validation loss decreased {best_loss:.4} --> {val_loss:.4}: saving state...")
                 torch.save(dict(model=model.state_dict(),
                                 optimizer=optimizer.state_dict(),
                                 lr_scheduler=lr_scheduler.state_dict(),

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -185,9 +185,11 @@ def main(args):
     setattr(model, 'fc', nn.Linear(in_features, num_classes))
 
     # Freeze layers
-    for n, p in model.named_parameters():
-        if not n.startswith('fc'):
-            p.requires_grad = False
+    if not args.unfreeze:
+        # Model is sequential
+        for n, p in model.named_parameters():
+            if not n.startswith('fc'):
+                p.requires_grad = False
 
     # Send to device
     model.to(args.device)
@@ -258,15 +260,13 @@ if __name__ == "__main__":
     parser.add_argument('--resume', default='', help='resume from checkpoint')
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
                         help='start epoch')
-    parser.add_argument(
-        "--deterministic",
-        dest="deterministic",
+    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
+                        action="store_true")
+    parser.add_argument("--deterministic", dest="deterministic",
         help="Should the training be performed in deterministic mode",
         action="store_true",
     )
-    parser.add_argument(
-        "--pretrained",
-        dest="pretrained",
+    parser.add_argument("--pretrained", dest="pretrained",
         help="Use pre-trained models from the modelzoo",
         action="store_true",
     )

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -274,9 +274,9 @@ if __name__ == "__main__":
                         dest='weight_decay')
     parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
-    parser.add_argument('--output-dir', default=None, help='path where to save')
-    parser.add_argument('--checkpoint', default=None, type=str, help='checkpoint file to resume from (default: None)')
-    parser.add_argument('--resume', default=None, help='resume from checkpoint')
+    parser.add_argument('--output-dir', default=None, help='path for output saving')
+    parser.add_argument('--checkpoint', default=None, type=str, help='name of output file')
+    parser.add_argument('--resume', default=None, help='checkpoint file to resume from (default: None)')
     parser.add_argument("--binary", dest="binary", help="Should the task be considered as binary Classification",
                         action="store_true")
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
     parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
     parser.add_argument('--output-dir', default=None, help='path where to save')
-    parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
+    parser.add_argument('--checkpoint', default=None, type=str, help='checkpoint file to resume from (default: None)')
     parser.add_argument('--resume', default=None, help='resume from checkpoint')
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
                         help='start epoch')

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -183,6 +183,13 @@ def main(args):
     # Change fc
     in_features = getattr(model, 'fc').in_features
     setattr(model, 'fc', nn.Linear(in_features, num_classes))
+
+    # Freeze layers
+    for n, p in model.named_parameters():
+        if not n.startswith('fc'):
+            p.requires_grad = False
+
+    # Send to device
     model.to(args.device)
 
     # Loss function


### PR DESCRIPTION
This PR aims at reducing the discrepancies between training run with fastai and bare pytorch. The later was running by default with fully unfrozen model while the first was only unfreezing the fully connected layers.

Also added checkpoint resuming option on both scripts, and a binary classification option on the pytorch script