### PR TITLE
feat: add argument num_samples to OpenFire

### DIFF
--- a/pyronear/datasets/openfire.py
+++ b/pyronear/datasets/openfire.py
@@ -31,6 +31,7 @@ class OpenFire(VisionDataset):
             downloaded again.
         threads (int, optional): If download is set to True, use this amount of threads
             for downloading the dataset.
+        num_samples (int, optional): Number of samples to download (all by default)
     """
 
     url = 'https://gist.githubusercontent.com/frgfm/f53b4f53a1b2dc3bb4f18c006a32ec0d/raw/c0351134e333710c6ce0c631af5198e109ed7a92/openfire_binary.json'
@@ -38,12 +39,12 @@ class OpenFire(VisionDataset):
     test_file = 'test.pt'
     classes = [False, True]
 
-    def __init__(self, root, train=True, download=False, threads=16, **kwargs):
+    def __init__(self, root, train=True, download=False, threads=16, num_samples=None, **kwargs):
         super(OpenFire, self).__init__(root, **kwargs)
         self.train = train  # training set or test set
 
         if download:
-            self.download(threads)
+            self.download(threads, num_samples)
 
         if not self._check_exists(train):
             raise RuntimeError('Dataset not found.' +
@@ -96,11 +97,12 @@ class OpenFire(VisionDataset):
         else:
             return self._root.joinpath(self._processed, self.test_file).is_file()
 
-    def download(self, threads=None):
+    def download(self, threads=None, num_samples=None):
         """Download the OpenFire data if it doesn't exist in processed_folder already.
 
         Args:
             threads (int, optional): Number of threads to use for dataset downloading.
+            num_samples (int, optional): Number of samples to download (all by default)
         """
 
         if self._check_exists(train=True) and self._check_exists(train=False):
@@ -112,7 +114,7 @@ class OpenFire(VisionDataset):
         # Download annotations
         download_url(self.url, self._root.joinpath(self._raw), filename=self.url.rpartition('/')[-1], verbose=False)
         with open(self._root.joinpath(self._raw, self.url.rpartition('/')[-1]), 'rb') as f:
-            annotations = json.load(f)
+            annotations = json.load(f)[:num_samples]
 
         # Download actual images
         training_set, test_set = [], []

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -47,8 +47,8 @@ class TestCollectEnv(unittest.TestCase):
         with Path(tempfile.TemporaryDirectory().name) as root:
 
             # Working case
-            train_set = datasets.OpenFire(root=root, train=True, download=True)
-            test_set = datasets.OpenFire(root=root, train=False, download=True)
+            train_set = datasets.OpenFire(root=root, train=True, download=True, num_samples=200)
+            test_set = datasets.OpenFire(root=root, train=False, download=True, num_samples=200)
             # Check inherited properties
             self.assertIsInstance(train_set, VisionDataset)
 
@@ -58,12 +58,12 @@ class TestCollectEnv(unittest.TestCase):
             self.assertTrue(all(sample['path'].name.rpartition('.')[-1] in ['jpg', 'jpeg', 'png', 'gif']
                                 for sample in test_set.data))
 
-            # Check against number of samples in extract
+            # Check against number of samples in extract (limit to 200)
             datasets.utils.download_url(train_set.url, root, filename='extract.json', verbose=False)
             with open(root.joinpath('extract.json'), 'rb') as f:
-                extract = json.load(f)
+                extract = json.load(f)[:200]
             # Uncomment when download issues are resolved
-            # self.assertEqual(len(dataset), len(extract))
+            # self.assertEqual(len(train_set) + len(test_set), len(extract))
 
             # Check integrity of samples
             img, target = train_set[0]

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -43,12 +43,13 @@ class TestCollectEnv(unittest.TestCase):
             self.assertTrue(all(Path(root, url.rpartition('/')[-1]).is_file() for url in urls))
 
     def test_openfire(self):
+        num_samples = 200
 
         with Path(tempfile.TemporaryDirectory().name) as root:
 
             # Working case
-            train_set = datasets.OpenFire(root=root, train=True, download=True, num_samples=200)
-            test_set = datasets.OpenFire(root=root, train=False, download=True, num_samples=200)
+            train_set = datasets.OpenFire(root=root, train=True, download=True, num_samples=num_samples)
+            test_set = datasets.OpenFire(root=root, train=False, download=True, num_samples=num_samples)
             # Check inherited properties
             self.assertIsInstance(train_set, VisionDataset)
 
@@ -58,10 +59,10 @@ class TestCollectEnv(unittest.TestCase):
             self.assertTrue(all(sample['path'].name.rpartition('.')[-1] in ['jpg', 'jpeg', 'png', 'gif']
                                 for sample in test_set.data))
 
-            # Check against number of samples in extract (limit to 200)
+            # Check against number of samples in extract (limit to num_samples)
             datasets.utils.download_url(train_set.url, root, filename='extract.json', verbose=False)
             with open(root.joinpath('extract.json'), 'rb') as f:
-                extract = json.load(f)[:200]
+                extract = json.load(f)[:num_samples]
             # Uncomment when download issues are resolved
             # self.assertEqual(len(train_set) + len(test_set), len(extract))
 


### PR DESCRIPTION
Add the possibility to limit the number of samples to be downloaded, as discussed in #26. The default value is None, meaning all samples will be downloaded as before. Limited to 200 in test_datasets.py