### PR TITLE
feat: Added the models module

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,8 +21,8 @@ import sphinx_rtd_theme
 
 master_doc = 'index'
 project = 'pyronear'
-copyright = '2019, PyroNear Contibutors'
-author = 'PyroNear Contibutors'
+copyright = '2019, PyroNear Contributors'
+author = 'PyroNear Contributors'
 
 # The full version, including alpha/beta/rc tags
 version = pyronear.__version__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ for wildfire detection tasks.
    :caption: Package Reference
 
    datasets
+   models
    utils
 
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1,0 +1,17 @@
+pyronear.models
+===============
+
+The models subpackage contains definitions of models for addressing different tasks, including: image classification, object detection, and semantic segmentation.
+
+The following models are available:
+
+.. contents:: Models
+    :local:
+
+.. currentmodule:: pyronear.models
+
+
+ResNet
+~~~~~~~
+
+.. autofunction:: resnet

--- a/pyronear/__init__.py
+++ b/pyronear/__init__.py
@@ -1,3 +1,4 @@
 from pyronear import datasets
+from pyronear import models
 from pyronear import utils
 from .version import __version__

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,0 +1,1 @@
+from .resnet import *

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,1 +1,1 @@
-from .resnet import *
+from .resnet import resnet

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -1,0 +1,52 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+from torchvision.models.resnet import BasicBlock, Bottleneck, ResNet
+from torchvision.models.utils import load_state_dict_from_url
+
+
+resnet_layers = {
+    18: [2, 2, 2, 2],
+    34: [3, 4, 6, 3],
+    50: [3, 4, 6, 3],
+    101: [3, 4, 23, 3],
+    152: [3, 8, 36, 3]
+}
+
+model_urls = {
+	18: 'https://srv-file4.gofile.io/download/zE0DJG/resnet18-binary-classification.pth'
+}
+
+
+def resnet(depth, pretrained=False, progress=True, bin_classif=True, **kwargs):
+    """Instantiate a ResNet model for image classification
+
+    Args:
+        depth (int): depth of the model
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        bin_classif (bool, optional): whether the target task is binary classification
+        **kwargs: optional arguments of torchvision.models.resnet.ResNet
+
+    Returns:
+        model (torch.nn.Module): loaded model
+    """
+
+    # Task resolution
+    if bin_classif:
+        num_classes = 1
+    else:
+        raise NotImplementedError('architecture not implemented for this task')
+
+    # Model creation
+    block = Bottleneck if depth >= 50 else BasicBlock
+    model = ResNet(block, resnet_layers[depth], num_classes=1, **kwargs)
+
+    # Parameter loading
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[depth],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+
+    return model

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -41,7 +41,7 @@ def resnet(depth, pretrained=False, progress=True, bin_classif=True, **kwargs):
 
     # Model creation
     block = Bottleneck if depth >= 50 else BasicBlock
-    model = ResNet(block, resnet_layers[depth], num_classes=1, **kwargs)
+    model = ResNet(block, resnet_layers[depth], num_classes=num_classes, **kwargs)
 
     # Parameter loading
     if pretrained:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import subprocess
 from setuptools import setup, find_packages
 
 
-version = '0.1.0b0'
+version = '0.1.0rc1'
 sha = 'Unknown'
 package_name = 'pyronear'
 
@@ -49,24 +49,27 @@ setup(
     # Metadata
     name=package_name,
     version=version,
-    author='François-Guillaume Fernandez',
-    description='Modules, operations and models for wildfire detection in PyTorch',
+    author='PyroNear Contributors',
+    author_email='pyronear.d4g@gmail.com',
+    maintainer='François-Guillaume Fernandez',
+    description='Datasets and models for wildfire detection in PyTorch',
     long_description=readme,
     long_description_content_type="text/markdown",
     url='https://github.com/frgfm/PyroNear',
     license='MIT',
     classifiers=[
-        'Development Status :: 1 - Planning',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Natural Language :: English',
         'Topic :: Scientific/Engineering :: Artificial Intelligence'
     ],
     keywords=['pytorch', 'deep learning', 'vision', 'models',
-              'wildifre', 'object detection'],
+              'wildfire', 'object detection'],
 
     # Package info
     packages=find_packages(exclude=('test',)),

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -9,7 +9,7 @@ from torchvision.datasets import VisionDataset
 from pyronear import datasets
 
 
-class TestCollectEnv(unittest.TestCase):
+class DatasetsTester(unittest.TestCase):
     def test_downloadurl(self):
         # Valid input
         url = 'https://gist.githubusercontent.com/yrevar/942d3a0ac09ec9e5eb3a/raw/238f720ff059c1f82f368259d1ca4ffa5dd8f9f5/imagenet1000_clsidx_to_labels.txt'

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,30 @@
+import unittest
+import torch
+from pyronear import models
+
+
+class ModelsTester(unittest.TestCase):
+    def test_resnet(self):
+
+        # Test parameters
+        img_shape = (3, 224, 224)
+        bin_classif = True
+
+        # Generated inputs
+        img_tensor = torch.rand(img_shape)
+        num_classes = 1 if bin_classif else None
+
+        # Non-binary classification
+        self.assertRaises(NotImplementedError, models.resnet,
+                          depth=18, pretrained=True, bin_classif=False)
+
+        # Working case
+        model = models.resnet(depth=18, pretrained=True, bin_classif=True).eval()
+        with torch.no_grad():
+            out = model(img_tensor.unsqueeze(0))
+
+        self.assertEqual(out.shape, (1, num_classes))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -16,10 +16,10 @@ class ModelsTester(unittest.TestCase):
 
         # Non-binary classification
         self.assertRaises(NotImplementedError, models.resnet,
-                          depth=18, pretrained=True, bin_classif=False)
+                          depth=18, bin_classif=False)
 
         # Working case
-        model = models.resnet(depth=18, pretrained=True, bin_classif=True).eval()
+        model = models.resnet(depth=18, bin_classif=bin_classif).eval()
         with torch.no_grad():
             out = model(img_tensor.unsqueeze(0))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,7 +2,7 @@ import unittest
 from pyronear import utils
 
 
-class TestCollectEnv(unittest.TestCase):
+class UtilsTester(unittest.TestCase):
     def test_prettyenv(self):
         info_output = utils.get_pretty_env_info()
         self.assertTrue(info_output.count('\n') >= 19)


### PR DESCRIPTION
This PR introduces the `models` module which:
- defines resnet architectures for binary classification (on `OpenFire`)
- allows pretrained parameters download when `pretrained=True`

Tests and documentation have been updated accordingly.
_Note: the only available pretrained model for now is a `resnet18`. Other variations will need to be added._

Any feedback is welcome!