### PR TITLE
feat: Unified model creation for CNN

### DIFF
--- a/docs/source/_static/css/custom_theme.css
+++ b/docs/source/_static/css/custom_theme.css
@@ -25,6 +25,10 @@ body {
 	background-color: #f3f4f7;
 }
 
+.wy-nav-content {
+    max-width: 900px;
+}
+
 .wy-nav-content-wrap, .wy-menu li.current > a  {
     background-color: #fff;
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ for wildfire detection tasks.
 
    datasets
    models
+   nn
    utils
 
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -12,6 +12,35 @@ The following models are available:
 
 
 ResNet
-~~~~~~~
+------
 
-.. autofunction:: resnet
+.. autofunction:: resnet18
+.. autofunction:: resnet34
+.. autofunction:: resnet50
+.. autofunction:: resnet101
+.. autofunction:: resnet152
+
+DenseNet
+---------
+
+.. autofunction:: densenet121
+.. autofunction:: densenet169
+.. autofunction:: densenet161
+.. autofunction:: densenet201
+
+MobileNet v2
+-------------
+
+.. autofunction:: mobilenet_v2
+
+ResNext
+-------
+
+.. autofunction:: resnext50_32x4d
+.. autofunction:: resnext101_32x8d
+
+Wide ResNet
+-----------
+
+.. autofunction:: wide_resnet50_2
+.. autofunction:: wide_resnet101_2

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -1,0 +1,18 @@
+pyronear.nn
+===========
+
+The nn subpackage contains definitions of modules and functions for Deep Learning architectures.
+
+The following models are available:
+
+.. automodule:: torch.nn
+.. currentmodule:: pyronear.nn
+
+
+Pooling layers
+--------------
+AdaptiveConcatPool2d
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AdaptiveConcatPool2d
+    :members:

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,2 +1,3 @@
 from .resnet import *
 from .densenet import *
+from .mobilenet import *

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,1 +1,2 @@
 from .resnet import *
+from .densenet import *

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,1 +1,1 @@
-from .resnet import resnet
+from .resnet import *

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,1 +1,1 @@
-from .resnet import *
+from .resnet import resnet18, resnet34, resnet50, resnet101, resnet152

--- a/pyronear/models/__init__.py
+++ b/pyronear/models/__init__.py
@@ -1,1 +1,1 @@
-from .resnet import resnet18, resnet34, resnet50, resnet101, resnet152
+from .resnet import *

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -34,7 +34,8 @@ def _update_state_dict(state_dict):
 
 
 def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=False,
-              progress=True, imagenet_pretrained=False, num_classes=1, **kwargs):
+              progress=True, imagenet_pretrained=False, num_classes=1, lin_features=None,
+              dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Instantiate a DenseNet model for image classification from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>
 
@@ -47,6 +48,10 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
         progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
+        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
         **kwargs: optional arguments of torchvision.models.densenet.DenseNet
 
     Returns:
@@ -70,8 +75,8 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
             raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
 
     # Cut at last conv layers
-    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier.in_features,
-                      num_classes=num_classes)
+    model = cnn_model(base_model, model_cut, base_model.classifier.in_features, num_classes,
+                      lin_features, dropout_prob, bn_final=bn_final, concat_pool=concat_pool)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -34,7 +34,7 @@ def _update_state_dict(state_dict):
 
 
 def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=False,
-              progress=True, imagenet_pretrained=False, num_classes=1, lin_features=None,
+              progress=True, imagenet_pretrained=False, num_classes=1, lin_features=512,
               dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Instantiate a DenseNet model for image classification from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>
@@ -48,7 +48,7 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
         progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
-        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
         dropout_prob (float, optional): dropout probability of head FC layers
         bn_final (bool, optional): should a batch norm be added after the last layer
         concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -36,27 +36,6 @@ def _update_state_dict(state_dict):
 def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=False,
               progress=True, imagenet_pretrained=False, num_classes=1, lin_features=512,
               dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
-    r"""Instantiate a DenseNet model for image classification from
-    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>
-
-    Args:
-        arch (str): densenet architecture
-        growth_rate (int): growth rate of each dense block
-        block_config (list<int>): number of blocks in each layer
-        num_init_features (int): number of output channels in the first convolution
-        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
-        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
-        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
-        num_classes (int, optional): number of output classes
-        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
-        dropout_prob (float, optional): dropout probability of head FC layers
-        bn_final (bool, optional): should a batch norm be added after the last layer
-        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
-        **kwargs: optional arguments of torchvision.models.densenet.DenseNet
-
-    Returns:
-        model (torch.nn.Module): loaded model
-    """
 
     # Model creation
     base_model = DenseNet(growth_rate, block_config, num_init_features, num_classes=num_classes, **kwargs)
@@ -87,53 +66,85 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
     return model
 
 
-def densenet121(*args, **kwargs):
+def densenet121(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Densenet-121 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
-          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.densenet.DenseNet`
     """
-    return _densenet('densenet121', 32, (6, 12, 24, 16), 64, *args, **kwargs)
+    return _densenet('densenet121', 32, (6, 12, 24, 16), 64, pretrained, progress,
+                     imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                     bn_final, concat_pool, **kwargs)
 
 
-def densenet161(*args, **kwargs):
+def densenet161(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Densenet-161 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
-          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.densenet.DenseNet`
     """
-    return _densenet('densenet161', 48, (6, 12, 36, 24), 96, *args, **kwargs)
+    return _densenet('densenet161', 48, (6, 12, 36, 24), 96, pretrained, progress,
+                     imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                     bn_final, concat_pool, **kwargs)
 
 
-def densenet169(*args, **kwargs):
+def densenet169(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Densenet-169 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
-          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.densenet.DenseNet`
     """
-    return _densenet('densenet169', 32, (6, 12, 32, 32), 64, *args, **kwargs)
+    return _densenet('densenet169', 32, (6, 12, 32, 32), 64, pretrained, progress,
+                     imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                     bn_final, concat_pool, **kwargs)
 
 
-def densenet201(*args, **kwargs):
+def densenet201(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Densenet-201 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
-          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.densenet.DenseNet`
     """
-    return _densenet('densenet201', 32, (6, 12, 48, 32), 64, *args, **kwargs)
+    return _densenet('densenet201', 32, (6, 12, 48, 32), 64, pretrained, progress,
+                     imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                     bn_final, concat_pool, **kwargs)

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -9,7 +9,9 @@ from .utils import cnn_model
 __all__ = ['densenet121', 'densenet169', 'densenet201', 'densenet161']
 
 
-model_urls = {}
+model_urls = {
+    'densenet121': 'https://srv-file7.gofile.io/download/XqHLBB/densenet121-binary-classification.pth'
+}
 
 model_cut = -1
 

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -81,16 +81,52 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
 
 
 def densenet121(*args, **kwargs):
+    r"""Densenet-121 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
+          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+    """
     return _densenet('densenet121', 32, (6, 12, 24, 16), 64, *args, **kwargs)
 
 
 def densenet161(*args, **kwargs):
+    r"""Densenet-161 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
+          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+    """
     return _densenet('densenet161', 48, (6, 12, 36, 24), 96, *args, **kwargs)
 
 
 def densenet169(*args, **kwargs):
+    r"""Densenet-169 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
+          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+    """
     return _densenet('densenet169', 32, (6, 12, 32, 32), 64, *args, **kwargs)
 
 
 def densenet201(*args, **kwargs):
+    r"""Densenet-201 model from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        memory_efficient (bool) - If True, uses checkpointing. Much more memory efficient,
+          but slower. Default: *False*. See `"paper" <https://arxiv.org/pdf/1707.06990.pdf>`_
+    """
     return _densenet('densenet201', 32, (6, 12, 48, 32), 64, *args, **kwargs)

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -69,7 +69,7 @@ def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=Fal
 
     # Cut at last conv layers
     model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier.in_features,
-                      num_classes=num_classes, concat_pool=True, bn_final=False)
+                      num_classes=num_classes)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/densenet.py
+++ b/pyronear/models/densenet.py
@@ -1,0 +1,96 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+import re
+from torchvision.models.densenet import DenseNet, model_urls as imagenet_urls
+from torchvision.models.utils import load_state_dict_from_url
+from .utils import cnn_model
+
+__all__ = ['densenet121', 'densenet169', 'densenet201', 'densenet161']
+
+
+model_urls = {}
+
+model_cut = -1
+
+
+def _update_state_dict(state_dict):
+    # '.'s are no longer allowed in module names, but previous _DenseLayer
+    # has keys 'norm.1', 'relu.1', 'conv.1', 'norm.2', 'relu.2', 'conv.2'.
+    # They are also in the checkpoints in model_urls. This pattern is used
+    # to find such keys.
+    pattern = re.compile(
+        r'^(.*denselayer\d+\.(?:norm|relu|conv))\.((?:[12])\.(?:weight|bias|running_mean|running_var))$')
+
+    for key in list(state_dict.keys()):
+        res = pattern.match(key)
+        if res:
+            new_key = res.group(1) + res.group(2)
+            state_dict[new_key] = state_dict[key]
+            del state_dict[key]
+    return state_dict
+
+
+def _densenet(arch, growth_rate, block_config, num_init_features, pretrained=False,
+              progress=True, imagenet_pretrained=False, num_classes=1, **kwargs):
+    r"""Instantiate a DenseNet model for image classification from
+    `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>
+
+    Args:
+        arch (str): densenet architecture
+        growth_rate (int): growth rate of each dense block
+        block_config (list<int>): number of blocks in each layer
+        num_init_features (int): number of output channels in the first convolution
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        **kwargs: optional arguments of torchvision.models.densenet.DenseNet
+
+    Returns:
+        model (torch.nn.Module): loaded model
+    """
+
+    # Model creation
+    base_model = DenseNet(growth_rate, block_config, num_init_features, num_classes=num_classes, **kwargs)
+    # Imagenet pretraining
+    if imagenet_pretrained:
+        if pretrained:
+            raise ValueError('imagenet_pretrained cannot be set to True if pretrained=True')
+        state_dict = load_state_dict_from_url(imagenet_urls[arch],
+                                              progress=progress)
+        state_dict = _update_state_dict(state_dict)
+        # Remove FC params from dict
+        for key in ('classifier.weight', 'classifier.bias'):
+            state_dict.pop(key, None)
+        missing, unexpected = base_model.load_state_dict(state_dict, strict=False)
+        if any(unexpected) or any(not elt.startswith('classifier.') for elt in missing):
+            raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
+
+    # Cut at last conv layers
+    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier.in_features,
+                      num_classes=num_classes, concat_pool=True, bn_final=False)
+
+    # Parameter loading
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+
+    return model
+
+
+def densenet121(*args, **kwargs):
+    return _densenet('densenet121', 32, (6, 12, 24, 16), 64, *args, **kwargs)
+
+
+def densenet161(*args, **kwargs):
+    return _densenet('densenet161', 48, (6, 12, 36, 24), 96, *args, **kwargs)
+
+
+def densenet169(*args, **kwargs):
+    return _densenet('densenet169', 32, (6, 12, 32, 32), 64, *args, **kwargs)
+
+
+def densenet201(*args, **kwargs):
+    return _densenet('densenet201', 32, (6, 12, 48, 32), 64, *args, **kwargs)

--- a/pyronear/models/mobilenet.py
+++ b/pyronear/models/mobilenet.py
@@ -46,7 +46,7 @@ def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
 
     # Cut at last conv layers
     model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier[1].in_features,
-                      num_classes=num_classes, concat_pool=True, bn_final=False)
+                      num_classes=num_classes)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/mobilenet.py
+++ b/pyronear/models/mobilenet.py
@@ -16,9 +16,9 @@ model_cut = -1
 
 
 def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
-                 num_classes=1, lin_features=None, dropout_prob=0.5,
+                 num_classes=1, lin_features=512, dropout_prob=0.5,
                  bn_final=False, concat_pool=True, **kwargs):
-    r"""Constructs a MobileNetV2 architecture from
+    r"""MobileNetV2 model from
     `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
 
     Args:
@@ -26,14 +26,11 @@ def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
         progress (bool): If True, displays a progress bar of the download to stderr
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
-        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
         dropout_prob (float, optional): dropout probability of head FC layers
         bn_final (bool, optional): should a batch norm be added after the last layer
-        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
-        **kwargs: optional arguments of torchvision.models.mobilenet.MobileNetV2
-
-    Returns:
-        model (torch.nn.Module): loaded model
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.mobilenet.MobileNetV2`
     """
 
     # Model creation

--- a/pyronear/models/mobilenet.py
+++ b/pyronear/models/mobilenet.py
@@ -16,7 +16,8 @@ model_cut = -1
 
 
 def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
-                 num_classes=1, **kwargs):
+                 num_classes=1, lin_features=None, dropout_prob=0.5,
+                 bn_final=False, concat_pool=True, **kwargs):
     r"""Constructs a MobileNetV2 architecture from
     `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
 
@@ -25,6 +26,10 @@ def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
         progress (bool): If True, displays a progress bar of the download to stderr
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
+        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
         **kwargs: optional arguments of torchvision.models.mobilenet.MobileNetV2
 
     Returns:
@@ -47,8 +52,8 @@ def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
             raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
 
     # Cut at last conv layers
-    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier[1].in_features,
-                      num_classes=num_classes)
+    model = cnn_model(base_model, model_cut, base_model.classifier[1].in_features, num_classes,
+                      lin_features, dropout_prob, bn_final=bn_final, concat_pool=concat_pool)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/mobilenet.py
+++ b/pyronear/models/mobilenet.py
@@ -8,7 +8,9 @@ from .utils import cnn_model
 __all__ = ['mobilenet_v2']
 
 
-model_urls = {}
+model_urls = {
+    'mobilenet_v2': 'https://srv-file7.gofile.io/download/RKagNy/mobilenet_v2-binary-classification.pth'
+}
 
 model_cut = -1
 

--- a/pyronear/models/mobilenet.py
+++ b/pyronear/models/mobilenet.py
@@ -1,0 +1,57 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+from torchvision.models.mobilenet import MobileNetV2, model_urls as imagenet_urls
+from torchvision.models.utils import load_state_dict_from_url
+from .utils import cnn_model
+
+__all__ = ['mobilenet_v2']
+
+
+model_urls = {}
+
+model_cut = -1
+
+
+def mobilenet_v2(pretrained=False, progress=True, imagenet_pretrained=False,
+                 num_classes=1, **kwargs):
+    r"""Constructs a MobileNetV2 architecture from
+    `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        **kwargs: optional arguments of torchvision.models.mobilenet.MobileNetV2
+
+    Returns:
+        model (torch.nn.Module): loaded model
+    """
+
+    # Model creation
+    base_model = MobileNetV2(num_classes=num_classes, **kwargs)
+    # Imagenet pretraining
+    if imagenet_pretrained:
+        if pretrained:
+            raise ValueError('imagenet_pretrained cannot be set to True if pretrained=True')
+        state_dict = load_state_dict_from_url(imagenet_urls['mobilenet_v2'],
+                                              progress=progress)
+        # Remove FC params from dict
+        for key in ('classifier.1.weight', 'classifier.1.bias'):
+            state_dict.pop(key, None)
+        missing, unexpected = base_model.load_state_dict(state_dict, strict=False)
+        if any(unexpected) or any(not elt.startswith('classifier.') for elt in missing):
+            raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
+
+    # Cut at last conv layers
+    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.classifier[1].in_features,
+                      num_classes=num_classes, concat_pool=True, bn_final=False)
+
+    # Parameter loading
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls['mobilenet_v2'],
+                                              progress=progress)
+        model.load_state_dict(state_dict)
+
+    return model

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -147,6 +147,7 @@ def wide_resnet50_2(*args, **kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
     Args:
         **kwargs: optional arguments of _resnet
     """
@@ -161,6 +162,7 @@ def wide_resnet101_2(*args, **kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
     Args:
         **kwargs: optional arguments of _resnet
     """

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -20,7 +20,8 @@ model_cut = -2
 
 
 def _resnet(arch, block, layers, pretrained=False, progress=True,
-            imagenet_pretrained=False, num_classes=1, **kwargs):
+            imagenet_pretrained=False, num_classes=1, lin_features=None,
+            dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Instantiate a ResNet model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
@@ -32,6 +33,10 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
         progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
+        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
         **kwargs: optional arguments of torchvision.models.resnet.ResNet
 
     Returns:
@@ -54,8 +59,8 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
             raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
 
     # Cut at last conv layers
-    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.fc.in_features,
-                      num_classes=num_classes)
+    model = cnn_model(base_model, model_cut, base_model.fc.in_features, num_classes,
+                      lin_features, dropout_prob, bn_final=bn_final, concat_pool=concat_pool)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -6,6 +6,9 @@ from torchvision.models.resnet import BasicBlock, Bottleneck, ResNet, model_urls
 from torchvision.models.utils import load_state_dict_from_url
 from .utils import cnn_model
 
+__all__ = ['resnet18', 'resnet34', 'resnet50', 'resnet101',
+           'resnet152', 'resnext50_32x4d', 'resnext101_32x8d',
+           'wide_resnet50_2', 'wide_resnet101_2']
 
 model_urls = {
     'resnet18': 'https://srv-file7.gofile.io/download/rG1vDJ/resnet18-binary-classification.pth',
@@ -63,21 +66,103 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
     return model
 
 
-def resnet18(*args, **kwargs):
-    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], *args, **kwargs)
+def resnet18(**kwargs):
+    r"""ResNet-18 model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], **kwargs)
 
 
 def resnet34(*args, **kwargs):
+    r"""ResNet-34 model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
     return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], *args, **kwargs)
 
 
 def resnet50(*args, **kwargs):
+    r"""ResNet-50 model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
     return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
 
 
 def resnet101(*args, **kwargs):
+    r"""ResNet-101 model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
     return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
 
 
 def resnet152(*args, **kwargs):
+    r"""ResNet-152 model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
     return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], *args, **kwargs)
+
+
+def resnext50_32x4d(*args, **kwargs):
+    r"""ResNeXt-50 32x4d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 4
+    return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+
+
+def resnext101_32x8d(*args, **kwargs):
+    r"""ResNeXt-101 32x8d model from
+    `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
+
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
+    kwargs['groups'] = 32
+    kwargs['width_per_group'] = 8
+    return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
+
+
+def wide_resnet50_2(*args, **kwargs):
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+
+
+def wide_resnet101_2(*args, **kwargs):
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+    Args:
+        **kwargs: optional arguments of _resnet
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3], *args, **kwargs)

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -11,9 +11,7 @@ __all__ = ['resnet18', 'resnet34', 'resnet50', 'resnet101',
            'wide_resnet50_2', 'wide_resnet101_2']
 
 model_urls = {
-    'resnet18': 'https://srv-file7.gofile.io/download/rG1vDJ/resnet18-binary-classification.pth',
-    'resnet34': 'https://srv-file7.gofile.io/download/W3gb2q/resnet34-binary-classification.pth',
-    'resnet50': 'https://srv-file4.gofile.io/download/R8xBvE/resnet50-binary-classification.pth'
+    'resnet18': 'https://srv-file6.gofile.io/download/5WANbz/resnet18-binary-classification.pth',
 }
 
 model_cut = -2

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -49,7 +49,7 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
 
     # Cut at last conv layers
     model = cnn_model(base_model, cut=-2, nb_features=base_model.fc.in_features,
-                      num_classes=num_classes)
+                      num_classes=num_classes, concat_pool=True, bn_final=False)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -2,51 +2,79 @@
 # -*- coding: utf-8 -*-
 
 
-from torchvision.models.resnet import BasicBlock, Bottleneck, ResNet
+from torchvision.models.resnet import BasicBlock, Bottleneck, ResNet, model_urls as imagenet_urls
 from torchvision.models.utils import load_state_dict_from_url
+from .utils import cnn_model
 
-
-resnet_layers = {
-    18: [2, 2, 2, 2],
-    34: [3, 4, 6, 3],
-    50: [3, 4, 6, 3],
-    101: [3, 4, 23, 3],
-    152: [3, 8, 36, 3]
-}
 
 model_urls = {
-    18: 'https://srv-file4.gofile.io/download/zE0DJG/resnet18-binary-classification.pth'
+    'resnet18': 'https://srv-file7.gofile.io/download/rG1vDJ/resnet18-binary-classification.pth',
+    'resnet34': 'https://srv-file7.gofile.io/download/W3gb2q/resnet34-binary-classification.pth'
 }
 
 
-def resnet(depth, pretrained=False, progress=True, bin_classif=True, **kwargs):
-    """Instantiate a ResNet model for image classification
+def _resnet(arch, block, layers, pretrained=False, progress=True,
+            imagenet_pretrained=False, num_classes=1, **kwargs):
+    r"""Instantiate a ResNet model for image classification from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        depth (int): depth of the model
+        arch (str): resnet architecture
+        block (torch.nn.Module): block used as bottleneck
+        layers (list<int>): number of blocks in each layer
         pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
         progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
-        bin_classif (bool, optional): whether the target task is binary classification
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
         **kwargs: optional arguments of torchvision.models.resnet.ResNet
 
     Returns:
         model (torch.nn.Module): loaded model
     """
 
-    # Task resolution
-    if bin_classif:
-        num_classes = 1
-    else:
-        raise NotImplementedError('architecture not implemented for this task')
-
     # Model creation
-    block = Bottleneck if depth >= 50 else BasicBlock
-    model = ResNet(block, resnet_layers[depth], num_classes=num_classes, **kwargs)
+    base_model = ResNet(block, layers, num_classes=num_classes, **kwargs)
+    # Imagenet pretraining
+    if imagenet_pretrained:
+        if pretrained:
+            raise ValueError('imagenet_pretrained cannot be set to True if pretrained=True')
+        state_dict = load_state_dict_from_url(imagenet_urls[arch],
+                                              progress=progress)
+        # Remove FC params from dict
+        for key in ('fc.weight', 'fc.bias'):
+            state_dict.pop(key, None)
+        missing, unexpected = base_model.load_state_dict(state_dict, strict=False)
+        if any(unexpected) or any(not elt.startswith('fc.') for elt in missing):
+            raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
+
+    # Cut at last conv layers
+    model = cnn_model(base_model, cut=-2, nb_features=base_model.fc.in_features,
+                      num_classes=num_classes)
 
     # Parameter loading
     if pretrained:
-        state_dict = load_state_dict_from_url(model_urls[depth],
+        state_dict = load_state_dict_from_url(model_urls[arch],
                                               progress=progress)
         model.load_state_dict(state_dict)
 
     return model
+
+
+def resnet18(*args, **kwargs):
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], *args, **kwargs)
+
+
+def resnet34(*args, **kwargs):
+    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], *args, **kwargs)
+
+
+def resnet50(*args, **kwargs):
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+
+
+def resnet101(*args, **kwargs):
+    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
+
+
+def resnet152(*args, **kwargs):
+    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], *args, **kwargs)

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -9,8 +9,11 @@ from .utils import cnn_model
 
 model_urls = {
     'resnet18': 'https://srv-file7.gofile.io/download/rG1vDJ/resnet18-binary-classification.pth',
-    'resnet34': 'https://srv-file7.gofile.io/download/W3gb2q/resnet34-binary-classification.pth'
+    'resnet34': 'https://srv-file7.gofile.io/download/W3gb2q/resnet34-binary-classification.pth',
+    'resnet50': 'https://srv-file4.gofile.io/download/R8xBvE/resnet50-binary-classification.pth'
 }
+
+model_cut = -2
 
 
 def _resnet(arch, block, layers, pretrained=False, progress=True,
@@ -48,7 +51,7 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
             raise KeyError(f"Missing parameters: {missing}\nUnexpected parameters: {unexpected}")
 
     # Cut at last conv layers
-    model = cnn_model(base_model, cut=-2, nb_features=base_model.fc.in_features,
+    model = cnn_model(base_model, cut=model_cut, nb_features=base_model.fc.in_features,
                       num_classes=num_classes, concat_pool=True, bn_final=False)
 
     # Parameter loading

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -12,6 +12,7 @@ __all__ = ['resnet18', 'resnet34', 'resnet50', 'resnet101',
 
 model_urls = {
     'resnet18': 'https://srv-file6.gofile.io/download/5WANbz/resnet18-binary-classification.pth',
+    'resnet34': 'https://srv-file7.gofile.io/download/ay3i9I/resnet34-binary-classification.pth'
 }
 
 model_cut = -2

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -20,28 +20,8 @@ model_cut = -2
 
 
 def _resnet(arch, block, layers, pretrained=False, progress=True,
-            imagenet_pretrained=False, num_classes=1, lin_features=None,
+            imagenet_pretrained=False, num_classes=1, lin_features=512,
             dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
-    r"""Instantiate a ResNet model for image classification from
-    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
-
-    Args:
-        arch (str): resnet architecture
-        block (torch.nn.Module): block used as bottleneck
-        layers (list<int>): number of blocks in each layer
-        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
-        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
-        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
-        num_classes (int, optional): number of output classes
-        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
-        dropout_prob (float, optional): dropout probability of head FC layers
-        bn_final (bool, optional): should a batch norm be added after the last layer
-        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
-        **kwargs: optional arguments of torchvision.models.resnet.ResNet
-
-    Returns:
-        model (torch.nn.Module): loaded model
-    """
 
     # Model creation
     base_model = ResNet(block, layers, num_classes=num_classes, **kwargs)
@@ -71,105 +51,206 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
     return model
 
 
-def resnet18(**kwargs):
+def resnet18(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+             lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNet-18 model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
-    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], **kwargs)
+    return _resnet('resnet18', BasicBlock, [2, 2, 2, 2], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnet34(*args, **kwargs):
+def resnet34(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+             lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNet-34 model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
-    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], *args, **kwargs)
+    return _resnet('resnet34', BasicBlock, [3, 4, 6, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnet50(*args, **kwargs):
+def resnet50(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+             lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNet-50 model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
-    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+    return _resnet('resnet50', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnet101(*args, **kwargs):
+def resnet101(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+              lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNet-101 model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
-    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
+    return _resnet('resnet101', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnet152(*args, **kwargs):
+def resnet152(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+              lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNet-152 model for image classification from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
-    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], *args, **kwargs)
+    return _resnet('resnet152', Bottleneck, [3, 8, 36, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnext50_32x4d(*args, **kwargs):
+def resnext50_32x4d(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                    lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNeXt-50 32x4d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 4
-    return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+    return _resnet('resnext50_32x4d', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def resnext101_32x8d(*args, **kwargs):
+def resnext101_32x8d(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                     lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""ResNeXt-101 32x8d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 8
-    return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
+    return _resnet('resnext101_32x8d', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def wide_resnet50_2(*args, **kwargs):
+def wide_resnet50_2(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                    lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Wide ResNet-50-2 model from
     `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
     The model is the same as ResNet except for the bottleneck number of channels
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
     kwargs['width_per_group'] = 64 * 2
-    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3], *args, **kwargs)
+    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)
 
 
-def wide_resnet101_2(*args, **kwargs):
+def wide_resnet101_2(pretrained=False, progress=True, imagenet_pretrained=False, num_classes=1,
+                     lin_features=512, dropout_prob=0.5, bn_final=False, concat_pool=True, **kwargs):
     r"""Wide ResNet-101-2 model from
     `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
     The model is the same as ResNet except for the bottleneck number of channels
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048.
 
     Args:
-        **kwargs: optional arguments of _resnet
+        pretrained (bool, optional): should pretrained parameters be loaded (OpenFire training)
+        progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
+        imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
+        num_classes (int, optional): number of output classes
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
+        dropout_prob (float, optional): dropout probability of head FC layers
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by :mod:`pyronear.nn.AdaptiveConcatPool2d`
+        **kwargs: optional arguments of :mod:`torchvision.models.resnet.ResNet`
     """
     kwargs['width_per_group'] = 64 * 2
-    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3], *args, **kwargs)
+    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3], pretrained, progress,
+                   imagenet_pretrained, num_classes, lin_features, dropout_prob,
+                   bn_final, concat_pool, **kwargs)

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -55,7 +55,7 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
 
     # Cut at last conv layers
     model = cnn_model(base_model, cut=model_cut, nb_features=base_model.fc.in_features,
-                      num_classes=num_classes, concat_pool=True, bn_final=False)
+                      num_classes=num_classes)
 
     # Parameter loading
     if pretrained:

--- a/pyronear/models/resnet.py
+++ b/pyronear/models/resnet.py
@@ -33,7 +33,7 @@ def _resnet(arch, block, layers, pretrained=False, progress=True,
         progress (bool, optional): should a progress bar be displayed while downloading pretrained parameters
         imagenet_pretrained (bool, optional): should pretrained parameters be loaded on conv layers (ImageNet training)
         num_classes (int, optional): number of output classes
-        lin_features (list<int>, optional): number of nodes in intermediate layers of model's head
+        lin_features (Union[int, list<int>], optional): number of nodes in intermediate layers of model's head
         dropout_prob (float, optional): dropout probability of head FC layers
         bn_final (bool, optional): should a batch norm be added after the last layer
         concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d

--- a/pyronear/models/utils.py
+++ b/pyronear/models/utils.py
@@ -1,0 +1,127 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Based on https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py
+
+import torch
+import numpy as np
+import torch.nn as nn
+from ..nn import AdaptiveConcatPool2d
+
+
+class Flatten(nn.Module):
+    """Implements a flattening layer"""
+    def __init__(self):
+        super(Flatten, self).__init__()
+
+    def forward(self, x):
+        return x.view(x.size(0), -1)
+
+
+def head_stack(in_features, out_features, bn=True, p=0., actn=None):
+    """Stacks batch norm, dropout and fully connected layers together
+
+    Args:
+        in_features (int): number of input features
+        out_features (int): number of output features
+        bn (bool, optional): should batchnorm be added
+        p (float, optional): dropout probability
+        actn (callable, optional): activation function
+    Returns:
+        torch.nn.Module: classifier head
+    """
+    layers = [nn.BatchNorm1d(in_features)] if bn else []
+    if p != 0:
+        layers.append(nn.Dropout(p))
+    layers.append(nn.Linear(in_features, out_features))
+    if actn is not None:
+        layers.append(actn)
+    return layers
+
+
+def create_head(in_features, num_classes, lin_features=None, dropout_prob=0.5,
+                bn_final=False, concat_pool=True):
+    """Instantiate a classifier head
+
+    Args:
+        in_features (int): number of input features
+        num_classes (int): number of output classes
+        lin_features (list<int>, optional): number of nodes in intermediate layers
+        dropout_prob (float, optional): dropout probability
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
+    Returns:
+        torch.nn.Module: classifier head
+    """
+    # Pooling
+    if concat_pool:
+        pool = AdaptiveConcatPool2d((1, 1))
+        in_features *= 2
+    else:
+        pool = nn.AdaptiveAvgPool2d((1, 1))
+
+    # Nodes' layout
+    if isinstance(lin_features, list):
+        lin_features = [in_features] + lin_features + [num_classes]
+    else:
+        lin_features = [in_features, 512, num_classes]
+
+    # Add half dropout probabilities for penultimate FC
+    dropout_prob = [dropout_prob]
+    if len(dropout_prob) == 1:
+        dropout_prob = [dropout_prob[0] / 2] * (len(lin_features) - 2) + dropout_prob
+    # ReLU activations except last FC
+    activations = [nn.ReLU(inplace=True)] * (len(lin_features) - 2) + [None]
+
+    # Flatten pooled feature maps
+    layers = [pool, Flatten()]
+    for in_feats, out_feats, prob, activation in zip(lin_features[:-1], lin_features[1:], dropout_prob, activations):
+        layers.extend(head_stack(in_feats, out_feats, True, prob, activation))
+    # Final batch norm
+    if bn_final:
+        layers.append(nn.BatchNorm1d(lin_features[-1], momentum=0.01))
+
+    return nn.Sequential(*layers)
+
+
+def create_body(model, cut):
+    """Extracts the convolutional features from a model
+
+    Args:
+        model (torch.nn.Module): model
+        cut (int): index of the first non-convolutional layer
+    Returns:
+        torch.nn.Module: model convolutional layerd
+    """
+
+    return nn.Sequential(*list(model.children())[:cut])
+
+
+def cnn_model(base_model, cut, nb_features=None, num_classes=None, lin_features=None,
+              dropout_prob=0.5, custom_head=None, bn_final=False, concat_pool=None):
+    """Create a model with standard high-level structure as a torch.nn.Sequential
+
+    Args:
+        base_model (torch.nn.Module): base model
+        cut (int): index of the first non-convolutional layer
+        nb_features (int): number of convolutional features
+        num_classes (int): number of output classes
+        lin_features (list<int>, optional): number of nodes in intermediate layers
+        dropout_prob (float, optional): dropout probability
+        custom_head (torch.nn.Module, optional): replacement for model's head
+        bn_final (bool, optional): should a batch norm be added after the last layer
+        concat_pool (bool, optional): should pooling be replaced by AdaptiveConcatPool2d
+    Returns:
+        torch.nn.Module: instantiated model
+    """
+
+    body = create_body(base_model, cut)
+    if custom_head is None:
+        # Number of features
+        if not (isinstance(nb_features, int) and isinstance(num_classes, int)):
+            raise ValueError('nb_features & num_classes need to be specified when custom_head is None')
+        head = create_head(nb_features, num_classes, lin_features, dropout_prob, bn_final, concat_pool)
+    else:
+        head = custom_head
+
+    return nn.Sequential(body, head)

--- a/pyronear/models/utils.py
+++ b/pyronear/models/utils.py
@@ -19,15 +19,13 @@ def init_module(m, init=nn.init.kaiming_normal_):
         init (callable, optional): inplace initializer function
     """
 
-    for n, p in m.named_parameters():
-        # Check if parameter is learnable
-        if p.requires_grad:
-            # Apply init to weights
-            if n == 'weight':
-                init(p)
-            # Set biases to 0.
-            elif (n == 'bias') and hasattr(p, 'data'):
-                p.data.fill_(0.)
+    # Apply init to learnable weights
+    if hasattr(m, 'weight') and m.weight.requires_grad:
+        init(m.weight)
+
+    # Set learnable biases to 0.
+    if hasattr(m, 'bias') and m.bias.requires_grad and hasattr(m.bias, 'data'):
+        m.bias.data.fill_(0.)
 
 
 class Flatten(nn.Module):

--- a/pyronear/models/utils.py
+++ b/pyronear/models/utils.py
@@ -13,7 +13,8 @@ class Flatten(nn.Module):
     def __init__(self):
         super(Flatten, self).__init__()
 
-    def forward(self, x):
+    @staticmethod
+    def forward(x):
         return x.view(x.size(0), -1)
 
 

--- a/pyronear/models/utils.py
+++ b/pyronear/models/utils.py
@@ -98,7 +98,7 @@ def create_body(model, cut):
 
 
 def cnn_model(base_model, cut, nb_features=None, num_classes=None, lin_features=None,
-              dropout_prob=0.5, custom_head=None, bn_final=False, concat_pool=None):
+              dropout_prob=0.5, custom_head=None, bn_final=False, concat_pool=True):
     """Create a model with standard high-level structure as a torch.nn.Sequential
 
     Args:

--- a/pyronear/models/utils.py
+++ b/pyronear/models/utils.py
@@ -3,8 +3,7 @@
 
 # Based on https://github.com/fastai/fastai/blob/master/fastai/vision/learner.py
 
-import torch
-import numpy as np
+
 import torch.nn as nn
 from ..nn import AdaptiveConcatPool2d
 

--- a/pyronear/nn/__init__.py
+++ b/pyronear/nn/__init__.py
@@ -1,0 +1,1 @@
+from .modules import *

--- a/pyronear/nn/functional.py
+++ b/pyronear/nn/functional.py
@@ -3,18 +3,18 @@
 
 # Based on https://github.com/fastai/fastai/blob/master/fastai/layers.py
 
+import torch
 import torch.nn.functional as F
 
 
-def adaptive_concat_pool2d(input, output_size, return_indices=False):
+def adaptive_concat_pool2d(input, output_size):
     """Concatenates a 2D adaptive max pooling and a 2D adaptive average pooling
     over an input signal composed of several input planes.
     See :class:`~torch.nn.AdaptiveConcatPool2d` for details and output shape.
     Args:
         output_size: the target output size (single integer or
             double-integer tuple)
-        return_indices: whether to return pooling indices. Default: ``False``
     """
 
-    return torch.cat([F.adaptive_max_pool2d(input, output_size, return_indices),
-                      F.adaptive_avg_pool2d(input, output_size, return_indices)], dim=1)
+    return torch.cat([F.adaptive_max_pool2d(input, output_size),
+                      F.adaptive_avg_pool2d(input, output_size)], dim=1)

--- a/pyronear/nn/functional.py
+++ b/pyronear/nn/functional.py
@@ -1,0 +1,20 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Based on https://github.com/fastai/fastai/blob/master/fastai/layers.py
+
+import torch.nn.functional as F
+
+
+def adaptive_concat_pool2d(input, output_size, return_indices=False):
+    """Concatenates a 2D adaptive max pooling and a 2D adaptive average pooling
+    over an input signal composed of several input planes.
+    See :class:`~torch.nn.AdaptiveConcatPool2d` for details and output shape.
+    Args:
+        output_size: the target output size (single integer or
+            double-integer tuple)
+        return_indices: whether to return pooling indices. Default: ``False``
+    """
+
+    return torch.cat([F.adaptive_max_pool2d(input, output_size, return_indices),
+                      F.adaptive_avg_pool2d(input, output_size, return_indices)], dim=1)

--- a/pyronear/nn/functional.py
+++ b/pyronear/nn/functional.py
@@ -7,7 +7,7 @@ import torch
 import torch.nn.functional as F
 
 
-def adaptive_concat_pool2d(input, output_size):
+def adaptive_concat_pool2d(x, output_size):
     """Concatenates a 2D adaptive max pooling and a 2D adaptive average pooling
     over an input signal composed of several input planes.
     See :class:`~torch.nn.AdaptiveConcatPool2d` for details and output shape.
@@ -16,5 +16,5 @@ def adaptive_concat_pool2d(input, output_size):
             double-integer tuple)
     """
 
-    return torch.cat([F.adaptive_max_pool2d(input, output_size),
-                      F.adaptive_avg_pool2d(input, output_size)], dim=1)
+    return torch.cat([F.adaptive_max_pool2d(x, output_size),
+                      F.adaptive_avg_pool2d(x, output_size)], dim=1)

--- a/pyronear/nn/modules/__init__.py
+++ b/pyronear/nn/modules/__init__.py
@@ -1,0 +1,1 @@
+from .pooling import AdaptiveConcatPool2d

--- a/pyronear/nn/modules/pooling.py
+++ b/pyronear/nn/modules/pooling.py
@@ -13,11 +13,13 @@ class AdaptiveConcatPool2d(nn.Module):
     signal composed of several input planes and concatenates them.
     The output is of size H x W, for any input size.
     The number of output features is equal to twice the number of input planes.
+
     Args:
-        output_size: the target output size of the image of the form H x W.
-                     Can be a tuple (H, W) or a single H for a square image H x H.
-                     H and W can be either a ``int``, or ``None`` which means the size will
-                     be the same as that of the input.
+        output_size (Union[int, tuple<int>]): the target output size of the image of the form H x W.
+            Can be a tuple (H, W) or a single H for a square image H x H.
+            H and W can be either a ``int``, or ``None`` which means the size will
+            be the same as that of the input.
+
     Examples:
         >>> # target output size of 5x7
         >>> m = nn.AdaptiveConcatPool2d((5,7))

--- a/pyronear/nn/modules/pooling.py
+++ b/pyronear/nn/modules/pooling.py
@@ -4,7 +4,6 @@
 # Based on https://github.com/fastai/fastai/blob/master/fastai/layers.py
 
 
-import torch
 import torch.nn as nn
 from .. import functional as F
 
@@ -39,9 +38,8 @@ class AdaptiveConcatPool2d(nn.Module):
         super(AdaptiveConcatPool2d, self).__init__()
         self.output_size = output_size
 
-    def forward(self, input):
-        # return torch.cat([self.mp(input), self.ap(input)], 1)
-        return F.adaptive_concat_pool2d(input, self.output_size)
+    def forward(self, x):
+        return F.adaptive_concat_pool2d(x, self.output_size)
 
     def extra_repr(self):
         return 'output_size={}'.format(self.output_size)

--- a/pyronear/nn/modules/pooling.py
+++ b/pyronear/nn/modules/pooling.py
@@ -1,0 +1,47 @@
+#!usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Based on https://github.com/fastai/fastai/blob/master/fastai/layers.py
+
+
+import torch
+import torch.nn as nn
+from .. import functional as F
+
+
+class AdaptiveConcatPool2d(nn.Module):
+    r"""Applies both a 2D adaptive max pooling and a 2D adaptive average pooling over an input
+    signal composed of several input planes and concatenates them.
+    The output is of size H x W, for any input size.
+    The number of output features is equal to twice the number of input planes.
+    Args:
+        output_size: the target output size of the image of the form H x W.
+                     Can be a tuple (H, W) or a single H for a square image H x H.
+                     H and W can be either a ``int``, or ``None`` which means the size will
+                     be the same as that of the input.
+    Examples:
+        >>> # target output size of 5x7
+        >>> m = nn.AdaptiveConcatPool2d((5,7))
+        >>> input = torch.randn(1, 64, 8, 9)
+        >>> output = m(input)
+        >>> # target output size of 7x7 (square)
+        >>> m = nn.AdaptiveConcatPool2d(7)
+        >>> input = torch.randn(1, 64, 10, 9)
+        >>> output = m(input)
+        >>> # target output size of 10x7
+        >>> m = nn.AdaptiveConcatPool2d((None, 7))
+        >>> input = torch.randn(1, 64, 10, 9)
+        >>> output = m(input)
+    """
+    __constants__ = ['output_size', 'return_indices']
+
+    def __init__(self, output_size):
+        super(AdaptiveConcatPool2d, self).__init__()
+        self.output_size = output_size
+
+    def forward(self, input):
+        # return torch.cat([self.mp(input), self.ap(input)], 1)
+        return F.adaptive_concat_pool2d(input, self.output_size)
+
+    def extra_repr(self):
+        return 'output_size={}'.format(self.output_size)

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -16,7 +16,6 @@ from fastai import vision
 from fastai.data_block import CategoryList, FloatList
 from fastai.basic_train import Learner
 from fastai.vision.learner import model_meta, _default_meta
-from fastai.torch_core import apply_init
 
 from pyronear.datasets import OpenFire
 from pyronear import models

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -121,48 +121,53 @@ def main(args):
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description='PyroNear Classification Training with Fastai')
+    parser = argparse.ArgumentParser(description='PyroNear Classification Training with Fastai',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Input / Output
-    parser.add_argument('--data-path', default='./data', help='dataset')
+    parser.add_argument('--data-path', default='./data', help='dataset root folder')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
-    parser.add_argument('--resume', default=None, help='checkpoint name to resume from (default: None)')
+    parser.add_argument('--resume', default=None, help='checkpoint name to resume from')
     # Architecture
-    parser.add_argument('--model', default='resnet18', type=str, help='model')
+    parser.add_argument('--model', default='resnet18', type=str, help='model architecture')
     parser.add_argument("--concat-pool", dest="concat_pool",
-                        help="Replaces AdaptiveAvgPool2d with AdaptiveConcatPool2d",
+                        help="replaces AdaptiveAvgPool2d with AdaptiveConcatPool2d",
                         action="store_true")
-    parser.add_argument('--lin-feats', default=512, type=int, help='Number of nodes in intermediate head layers')
+    parser.add_argument('--lin-feats', default=512, type=int,
+                        help='number of nodes in intermediate head layers')
     parser.add_argument("--bn-final", dest="bn_final",
-                        help="Adds a batch norm layer after last FC",
+                        help="adds a batch norm layer after last FC",
                         action="store_true")
     parser.add_argument('--dropout-prob', default=0.5, type=float, help='dropout rate of last FC layer')
-    parser.add_argument("--binary", dest="binary", help="Should the task be considered as binary Classification",
+    parser.add_argument("--binary", dest="binary",
+                        help="should the task be considered as binary Classification",
                         action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",
-                        help="Use pre-trained models from the modelzoo",
+                        help="use ImageNet pre-trained parameters",
                         action="store_true")
     # Device
-    parser.add_argument('--device', default='cuda', help='device')
+    parser.add_argument('--device', default=None, help='device')
     parser.add_argument("--deterministic", dest="deterministic",
-                        help="Should the training be performed in deterministic mode",
+                        help="should the training be performed in deterministic mode",
                         action="store_true")
     # Loader
-    parser.add_argument('-b', '--batch-size', default=32, type=int)
-    parser.add_argument('-s', '--resize', default=224, type=int)
+    parser.add_argument('-b', '--batch-size', default=32, type=int, help='batch size')
+    parser.add_argument('-s', '--resize', default=224, type=int, help='image size after resizing')
     parser.add_argument('-j', '--workers', default=16, type=int, metavar='N',
-                        help='number of data loading workers (default: 16)')
+                        help='number of data loading workers')
     # Optimizer
-    parser.add_argument('--lr', default=3e-3, type=float, help='initial learning rate')
+    parser.add_argument('--lr', default=3e-3, type=float, help='maximum learning rate')
     parser.add_argument('--epochs', default=10, type=int, metavar='N',
                         help='number of total epochs to run')
     parser.add_argument('--wd', '--weight-decay', default=1e-2, type=float,
-                        metavar='W', help='weight decay (default: 1e-2)',
+                        metavar='W', help='weight decay',
                         dest='weight_decay')
-    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
+    parser.add_argument("--unfreeze", dest="unfreeze", help="should all layers be unfrozen",
                         action="store_true")
     # Scheduler
-    parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
-    parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
+    parser.add_argument('--div-factor', default=25., type=float,
+                        help='div factor of OneCycle policy')
+    parser.add_argument('--final-div-factor', default=1e4, type=float,
+                        help='final div factor of OneCycle policy')
     args = parser.parse_args()
 
     main(args)

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -21,9 +21,9 @@ warnings.filterwarnings("ignore", category=UserWarning, module="torch.nn.functio
 
 class CustomBCELogitsLoss(nn.BCEWithLogitsLoss):
 
-    def forward(self, input, target):
+    def forward(self, x, target):
         # Reshape output tensor for BCELoss
-        return super(CustomBCELogitsLoss, self).forward(input, target.view(-1, 1))
+        return super(CustomBCELogitsLoss, self).forward(x, target.view(-1, 1))
 
 
 def main(args):

--- a/references/classification/fastai/train.py
+++ b/references/classification/fastai/train.py
@@ -93,7 +93,9 @@ def main(args):
     metric = partial(vision.accuracy_thresh, thresh=0.5) if args.binary else vision.error_rate
     # Create model
     model = models.__dict__[args.model](imagenet_pretrained=args.pretrained,
-                                        num_classes=data.c)
+                                        num_classes=data.c, lin_features=args.lin_feats,
+                                        concat_pool=args.concat_pool, bn_final=args.bn_final,
+                                        dropout_prob=args.dropout_prob)
     # Create learner
     learner = Learner(data, model,
                       wd=args.weight_decay,
@@ -113,7 +115,7 @@ def main(args):
         learner.unfreeze()
 
     learner.fit_one_cycle(args.epochs, max_lr=slice(None, args.lr, None),
-                          div_factor=args.div_factor)
+                          div_factor=args.div_factor, final_div=args.final_div_factor)
 
     learner.save(args.checkpoint)
 
@@ -121,32 +123,47 @@ def main(args):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='PyroNear Classification Training with Fastai')
+    # Input / Output
     parser.add_argument('--data-path', default='./data', help='dataset')
-    parser.add_argument('--model', default='resnet18', type=str, help='model')
-    parser.add_argument('--device', default='cuda', help='device')
-    parser.add_argument('-b', '--batch-size', default=32, type=int)
-    parser.add_argument('-s', '--resize', default=224, type=int)
-    parser.add_argument('--epochs', default=10, type=int, metavar='N',
-                        help='number of total epochs to run')
-    parser.add_argument('-j', '--workers', default=16, type=int, metavar='N',
-                        help='number of data loading workers (default: 16)')
-    parser.add_argument('--lr', default=3e-3, type=float, help='initial learning rate')
-    parser.add_argument('--wd', '--weight-decay', default=1e-2, type=float,
-                        metavar='W', help='weight decay (default: 1e-2)',
-                        dest='weight_decay')
-    parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
     parser.add_argument('--checkpoint', default='checkpoint', type=str, help='name of output file')
     parser.add_argument('--resume', default=None, help='checkpoint name to resume from (default: None)')
+    # Architecture
+    parser.add_argument('--model', default='resnet18', type=str, help='model')
+    parser.add_argument("--concat-pool", dest="concat_pool",
+                        help="Replaces AdaptiveAvgPool2d with AdaptiveConcatPool2d",
+                        action="store_true")
+    parser.add_argument('--lin-feats', default=512, type=int, help='Number of nodes in intermediate head layers')
+    parser.add_argument("--bn-final", dest="bn_final",
+                        help="Adds a batch norm layer after last FC",
+                        action="store_true")
+    parser.add_argument('--dropout-prob', default=0.5, type=float, help='dropout rate of last FC layer')
     parser.add_argument("--binary", dest="binary", help="Should the task be considered as binary Classification",
-                        action="store_true")
-    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
-                        action="store_true")
-    parser.add_argument("--deterministic", dest="deterministic",
-                        help="Should the training be performed in deterministic mode",
                         action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",
                         help="Use pre-trained models from the modelzoo",
                         action="store_true")
+    # Device
+    parser.add_argument('--device', default='cuda', help='device')
+    parser.add_argument("--deterministic", dest="deterministic",
+                        help="Should the training be performed in deterministic mode",
+                        action="store_true")
+    # Loader
+    parser.add_argument('-b', '--batch-size', default=32, type=int)
+    parser.add_argument('-s', '--resize', default=224, type=int)
+    parser.add_argument('-j', '--workers', default=16, type=int, metavar='N',
+                        help='number of data loading workers (default: 16)')
+    # Optimizer
+    parser.add_argument('--lr', default=3e-3, type=float, help='initial learning rate')
+    parser.add_argument('--epochs', default=10, type=int, metavar='N',
+                        help='number of total epochs to run')
+    parser.add_argument('--wd', '--weight-decay', default=1e-2, type=float,
+                        metavar='W', help='weight decay (default: 1e-2)',
+                        dest='weight_decay')
+    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
+                        action="store_true")
+    # Scheduler
+    parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
+    parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
     args = parser.parse_args()
 
     main(args)

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -10,7 +10,6 @@ import torch
 import torch.utils.data
 from torch import nn
 from torch import optim
-import torchvision
 from torchvision import transforms
 from fastprogress import master_bar, progress_bar
 

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -255,51 +255,56 @@ def main(args):
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description='PyroNear Classification Training')
+    parser = argparse.ArgumentParser(description='PyroNear Classification Training',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Input / Output
-    parser.add_argument('--data-path', default='./data', help='dataset')
-    parser.add_argument('--resume', default=None, help='checkpoint file to resume from (default: None)')
+    parser.add_argument('--data-path', default='./data', help='dataset root folder')
+    parser.add_argument('--resume', default=None, help='checkpoint file to resume from')
     parser.add_argument('--output-dir', default=None, help='path for output saving')
     parser.add_argument('--checkpoint', default=None, type=str, help='name of output file')
     parser.add_argument('--start-epoch', default=0, type=int, metavar='N',
-                        help='start epoch')
+                        help='start epoch index')
     # Architecture
-    parser.add_argument('--model', default='resnet18', type=str, help='model')
+    parser.add_argument('--model', default='resnet18', type=str, help='model architecture')
     parser.add_argument("--concat-pool", dest="concat_pool",
-                        help="Replaces AdaptiveAvgPool2d with AdaptiveConcatPool2d",
+                        help="replaces AdaptiveAvgPool2d with AdaptiveConcatPool2d",
                         action="store_true")
-    parser.add_argument('--lin-feats', default=512, type=int, help='Number of nodes in intermediate head layers')
+    parser.add_argument('--lin-feats', default=512, type=int,
+                        help='number of nodes in intermediate head layers')
     parser.add_argument("--bn-final", dest="bn_final",
-                        help="Adds a batch norm layer after last FC",
+                        help="adds a batch norm layer after last FC",
                         action="store_true")
     parser.add_argument('--dropout-prob', default=0.5, type=float, help='dropout rate of last FC layer')
-    parser.add_argument("--binary", dest="binary", help="Should the task be considered as binary Classification",
+    parser.add_argument("--binary", dest="binary",
+                        help="should the task be considered as binary Classification",
                         action="store_true")
     parser.add_argument("--pretrained", dest="pretrained",
-                        help="Use pre-trained models from the modelzoo",
+                        help="use ImageNet pre-trained parameters",
                         action="store_true")
     # Device
     parser.add_argument('--device', default=None, help='device')
     parser.add_argument("--deterministic", dest="deterministic",
-                        help="Should the training be performed in deterministic mode",
+                        help="should the training be performed in deterministic mode",
                         action="store_true")
     # Loader
-    parser.add_argument('-b', '--batch-size', default=32, type=int)
-    parser.add_argument('-s', '--resize', default=224, type=int)
+    parser.add_argument('-b', '--batch-size', default=32, type=int, help='batch size')
+    parser.add_argument('-s', '--resize', default=224, type=int, help='image size after resizing')
     parser.add_argument('-j', '--workers', default=16, type=int, metavar='N',
-                        help='number of data loading workers (default: 16)')
+                        help='number of data loading workers')
     # Optimizer
-    parser.add_argument('--lr', default=3e-4, type=float, help='initial learning rate')
+    parser.add_argument('--lr', default=3e-4, type=float, help='maximum learning rate')
     parser.add_argument('--epochs', default=20, type=int, metavar='N',
                         help='number of total epochs to run')
     parser.add_argument('--wd', '--weight-decay', default=1e-2, type=float,
-                        metavar='W', help='weight decay (default: 1e-2)',
+                        metavar='W', help='weight decay',
                         dest='weight_decay')
-    parser.add_argument("--unfreeze", dest="unfreeze", help="Should all layers be unfrozen",
+    parser.add_argument("--unfreeze", dest="unfreeze", help="should all layers be unfrozen",
                         action="store_true")
     # Scheduler
-    parser.add_argument('--div-factor', default=25., type=float, help='div factor of OneCycle policy')
-    parser.add_argument('--final-div-factor', default=1e4, type=float, help='final div factor of OneCycle policy')
+    parser.add_argument('--div-factor', default=25., type=float,
+                        help='div factor of OneCycle policy')
+    parser.add_argument('--final-div-factor', default=1e4, type=float,
+                        help='final div factor of OneCycle policy')
     args = parser.parse_args()
 
     main(args)

--- a/references/classification/torch/train.py
+++ b/references/classification/torch/train.py
@@ -161,6 +161,7 @@ def main(args):
 
     data_transforms = transforms.Compose([
         transforms.RandomResizedCrop((args.resize, args.resize)),
+        transforms.ColorJitter(brightness=0.3, contrast=0.3, saturation=0.1, hue=0.1),
         transforms.RandomHorizontalFlip(),
         transforms.RandomRotation(10),
         transforms.ToTensor(),

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -18,6 +18,38 @@ def get_available_classification_models():
 
 class ModelsTester(unittest.TestCase):
 
+    def test_create_head(self):
+
+        # Test parameters
+        in_features = 512
+        num_classes = 50
+        args_to_test = {'lin_features': [None, [256]],
+                        'bn_final': [False, True],
+                        'concat_pool': [False, True]}
+
+        # Valid input
+        input_tensor = torch.rand((512, 7, 7))
+
+        # Test optional arguments
+        for arg, vals in args_to_test.items():
+            for val in vals:
+                kwargs = {arg: val}
+                head = models.utils.create_head(in_features, num_classes, **kwargs).eval()
+                with torch.no_grad():
+                    self.assertEqual(head(input_tensor.unsqueeze(0)).size(1), num_classes)
+
+    def test_cnn_model(self):
+
+        # Test parameters
+        num_classes = 50
+
+        # Valid input
+        model = models.__dict__['mobilenet_v2'](num_classes=num_classes)
+
+        # No specified input features or number of classes
+        self.assertRaises(ValueError, models.utils.cnn_model, model, -1)
+
+
     def _test_classification_model(self, name, input_shape):
         # passing num_class equal to a number other than default helps in making the test
         # more enforcing in nature

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -23,12 +23,15 @@ class ModelsTester(unittest.TestCase):
         # Test parameters
         in_features = 512
         num_classes = 50
-        args_to_test = {'lin_features': [None, [256]],
+        args_to_test = {'lin_features': [256, [256]],
                         'bn_final': [False, True],
                         'concat_pool': [False, True]}
 
         # Valid input
         input_tensor = torch.rand((512, 7, 7))
+
+        # Invalid lin_features
+        self.assertRaises(TypeError, models.utils.create_head, in_features, num_classes, lin_features=None)
 
         # Test optional arguments
         for arg, vals in args_to_test.items():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,29 +1,44 @@
 import unittest
 import torch
+import numpy as np
+import random
 from pyronear import models
 
 
+def set_rng_seed(seed):
+    torch.manual_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+def get_available_classification_models():
+    # TODO add a registration mechanism to torchvision.models
+    return [k for k, v in models.__dict__.items() if callable(v) and k[0].lower() == k[0] and k[0] != "_"]
+
+
 class ModelsTester(unittest.TestCase):
-    def test_resnet(self):
 
-        # Test parameters
-        img_shape = (3, 224, 224)
-        bin_classif = True
-
-        # Generated inputs
-        img_tensor = torch.rand(img_shape)
-        num_classes = 1 if bin_classif else None
-
-        # Non-binary classification
-        self.assertRaises(NotImplementedError, models.resnet,
-                          depth=18, bin_classif=False)
-
-        # Working case
-        model = models.resnet(depth=18, bin_classif=bin_classif).eval()
+    def _test_classification_model(self, name, input_shape):
+        # passing num_class equal to a number other than 1000 helps in making the test
+        # more enforcing in nature
+        set_rng_seed(0)
+        model = models.__dict__[name](num_classes=50)
+        model.eval()
+        x = torch.rand(input_shape)
         with torch.no_grad():
-            out = model(img_tensor.unsqueeze(0))
+            out = model(x)
+        # self.assertExpected(out, rtol=1e-2, atol=0.)
+        self.assertEqual(out.shape[-1], 50)
 
-        self.assertEqual(out.shape, (1, num_classes))
+
+for model_name in get_available_classification_models():
+    # for-loop bodies don't define scopes, so we have to save the variables
+    # we want to close over in some way
+    def do_test(self, model_name=model_name):
+        input_shape = (1, 3, 224, 224)
+        self._test_classification_model(model_name, input_shape)
+
+    setattr(ModelsTester, "test_" + model_name, do_test)
 
 
 if __name__ == '__main__':

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -22,6 +22,7 @@ class ModelsTester(unittest.TestCase):
         # passing num_class equal to a number other than 1000 helps in making the test
         # more enforcing in nature
         set_rng_seed(0)
+        self.assertRaises(ValueError, models.__dict__[name], pretrained=True, imagenet_pretrained=True)
         model = models.__dict__[name](num_classes=50)
         model.eval()
         x = torch.rand(input_shape)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -19,11 +19,16 @@ def get_available_classification_models():
 class ModelsTester(unittest.TestCase):
 
     def _test_classification_model(self, name, input_shape):
-        # passing num_class equal to a number other than 1000 helps in making the test
+        # passing num_class equal to a number other than default helps in making the test
         # more enforcing in nature
         set_rng_seed(0)
+        num_classes = 50
+
+        # Pretrained parameters
         self.assertRaises(ValueError, models.__dict__[name], pretrained=True, imagenet_pretrained=True)
-        model = models.__dict__[name](num_classes=50)
+
+        # Default case
+        model = models.__dict__[name](num_classes=num_classes)
         model.eval()
         x = torch.rand(input_shape)
         with torch.no_grad():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -49,7 +49,6 @@ class ModelsTester(unittest.TestCase):
         # No specified input features or number of classes
         self.assertRaises(ValueError, models.utils.cnn_model, model, -1)
 
-
     def _test_classification_model(self, name, input_shape):
         # passing num_class equal to a number other than default helps in making the test
         # more enforcing in nature

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,0 +1,35 @@
+import unittest
+import torch
+from pyronear import nn
+
+# Based on https://github.com/pytorch/pytorch/blob/master/test/test_nn.py
+
+
+class NNTester(unittest.TestCase):
+
+    def test_adaptive_pooling_input_size(self):
+        for numel in (2,):
+            for pool_type in ('Concat',):
+                cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                module_cls = getattr(nn, cls_name)
+                output_size = (2,) * numel
+                module = module_cls(output_size)
+
+                input = torch.randn(output_size)
+                self.assertRaises(ValueError, lambda: module(input))
+
+    def test_adaptive_pooling_size_none(self):
+        for numel in (2,):
+            for pool_type in ('Concat',):
+                cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                module_cls = getattr(nn, cls_name)
+                output_size = (2,) * (numel - 1) + (None,)
+                module = module_cls(output_size)
+
+                input = torch.randn((4,) * (numel + 1))
+                output = module(input)
+                self.assertEqual(output.size(), (4,) + (4,) * (numel - 1) + (4,))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11,9 +11,8 @@ class NNTester(unittest.TestCase):
         for numel in (2,):
             for pool_type in ('Concat',):
                 cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
-                module_cls = getattr(nn, cls_name)
                 output_size = (2,) * numel
-                module = module_cls(output_size)
+                module = nn.__dict__[cls_name](output_size)
 
                 x = torch.randn(output_size)
                 self.assertRaises(ValueError, lambda: module(x))
@@ -22,9 +21,8 @@ class NNTester(unittest.TestCase):
         for numel in (2,):
             for pool_type in ('Concat',):
                 cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
-                module_cls = getattr(nn, cls_name)
                 output_size = (2,) * (numel - 1) + (None,)
-                module = module_cls(output_size)
+                module = nn.__dict__[cls_name](output_size)
 
                 x = torch.randn((4,) * (numel + 1))
                 output = module(x)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15,8 +15,8 @@ class NNTester(unittest.TestCase):
                 output_size = (2,) * numel
                 module = module_cls(output_size)
 
-                input = torch.randn(output_size)
-                self.assertRaises(ValueError, lambda: module(input))
+                x = torch.randn(output_size)
+                self.assertRaises(ValueError, lambda: module(x))
 
     def test_adaptive_pooling_size_none(self):
         for numel in (2,):
@@ -26,8 +26,8 @@ class NNTester(unittest.TestCase):
                 output_size = (2,) * (numel - 1) + (None,)
                 module = module_cls(output_size)
 
-                input = torch.randn((4,) * (numel + 1))
-                output = module(input)
+                x = torch.randn((4,) * (numel + 1))
+                output = module(x)
                 self.assertEqual(output.size(), (4,) + (4,) * (numel - 1) + (4,))
 
 


### PR DESCRIPTION
The PR proposes multiple features:
- new module `pyronear.models.utils`: tools for model creation which allows easy standardization of cnn models.
- update `pyronear.models`:  default model's head has been switched to the implementation of fastai, and pretrained parameters' urls have been updated. Variations of resnet, densenets and mobilenet have been added.
- update `references/classification`: both scripts now allow binary classification training and architectures are identical with default arguments.
- created `pyronear.nn`: added concatenated pooling module

Any feedback is welcome!