### PR TITLE
Add wildfire auto fire labeler

### DIFF
--- a/pyronear/datasets/wildfire/__init__.py
+++ b/pyronear/datasets/wildfire/__init__.py
@@ -1,0 +1,1 @@
+from .fire_labeler import FireLabeler

--- a/pyronear/datasets/wildfire/fire_labeler.py
+++ b/pyronear/datasets/wildfire/fire_labeler.py
@@ -1,8 +1,9 @@
 import re
-
 from itertools import combinations
+
 import numpy as np
 import pandas as pd
+
 
 class FireLabeler:
     """Automatically labelize WildFire dataset based on video descriptions
@@ -61,7 +62,7 @@ class FireLabeler:
         self.window_size = window_size or self.window_size
 
         self.n_videos_total = self.df.shape[0]
-        self.n_windows = self.n_videos_total - self.window_size + 1 # n_windows + windows_size < n_videos_total
+        self.n_windows = self.n_videos_total - self.window_size + 1  # n_windows + windows_size < n_videos_total
 
         # Store new column for fire ids starting at 0 (-1 for unassigned)
         self.fire_ids = np.full((self.n_videos_total), -1)
@@ -79,10 +80,10 @@ class FireLabeler:
 
         # sliding iterator over the video indexes. Example with window_size=4:
         # [[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5], ...]
-        window_idx_it = (range(start, start+self.window_size) for start in range(self.n_windows))
+        window_idx_it = (range(start, start + self.window_size) for start in range(self.n_windows))
 
-        current_fire_id = 0 # start grouping feu id at 0
-        for window_idx in window_idx_it: # for every window of videos
+        current_fire_id = 0  # start grouping feu id at 0
+        for window_idx in window_idx_it:  # for every window of videos
 
             # dict with {id: description(string)}
             id_to_descriptions = dict(zip(window_idx, self.df.loc[window_idx, 'description']))
@@ -97,17 +98,17 @@ class FireLabeler:
                         self.fire_ids[id_s2] = self.fire_ids[id_s1]
                     elif self.fire_ids[id_s2] != -1:
                         self.fire_ids[id_s1] = self.fire_ids[id_s2]
-                    else: # else we add new fire_id (first encounter)
+                    else:  # else we add new fire_id (first encounter)
                         self.fire_ids[id_s1] = current_fire_id
                         self.fire_ids[id_s2] = current_fire_id
                         current_fire_id = current_fire_id + 1
 
         # Now labeling the singletons
-        self._n_singletons = -1*self.fire_ids[self.fire_ids==-1].sum()
+        self._n_singletons = -1 * self.fire_ids[self.fire_ids == -1].sum()
 
-        length = len(self.fire_ids[self.fire_ids==-1])
-        self.fire_ids[self.fire_ids==-1] = range(current_fire_id, current_fire_id+length)
-        assert self.fire_ids[self.fire_ids==-1].sum() == 0, "Singletons escaped indexation!!"
+        length = len(self.fire_ids[self.fire_ids == -1])
+        self.fire_ids[self.fire_ids == -1] = range(current_fire_id, current_fire_id + length)
+        assert self.fire_ids[self.fire_ids == -1].sum() == 0, "Singletons escaped indexation!!"
         return self
 
     @staticmethod
@@ -115,7 +116,8 @@ class FireLabeler:
         """Compare two fire videos descriptions and guess if they match"""
 
         # regexp catching fire name (ex: Goose Fire)
-        p = re.compile(r"(?P<firename>\w+\sFire)") # compile once
+        p = re.compile(r"(?P<firename>\w+\sFire)")  # compile once
+
         def get_firename(string):
             """try to extract fire name"""
             result = p.search(string)
@@ -131,18 +133,15 @@ class FireLabeler:
         # - if same fire names found, it's a match.
         # - if 'Glen Fire' is found and 'Glen' is also found, it's a match
         # - if 'King Fire' is found and 'KingFire' as well, it's a match
-        firenames_match = (firename_s1 is not None
-                               and ((firename_s1 == firename_s2)
-                                    or firename_s1.split(' ')[0] in s2
-                                    or firename_s1.replace(' ','') in s2
-                                   )
-                          ) or (
-                            firename_s2 is not None
-                               and ((firename_s1 == firename_s2)
-                                    or firename_s2.split(' ')[0] in s1
-                                    or firename_s2.replace(' ','') in s1
-                                   )
-                          )
+        firenames_match = ((firename_s1 is not None
+                            and ((firename_s1 == firename_s2)
+                                 or firename_s1.split(' ')[0] in s2
+                                 or firename_s1.replace(' ', '') in s2))
+                           or (
+                           firename_s2 is not None
+                           and ((firename_s1 == firename_s2)
+                                or firename_s2.split(' ')[0] in s1
+                                or firename_s2.replace(' ', '') in s1)))
 
         return firenames_match
 

--- a/pyronear/datasets/wildfire/fire_labeler.py
+++ b/pyronear/datasets/wildfire/fire_labeler.py
@@ -2,7 +2,6 @@ import re
 from itertools import combinations
 
 import numpy as np
-import pandas as pd
 
 
 class FireLabeler:

--- a/pyronear/datasets/wildfire/fire_labeler.py
+++ b/pyronear/datasets/wildfire/fire_labeler.py
@@ -1,0 +1,152 @@
+import re
+
+from itertools import combinations
+import numpy as np
+import pandas as pd
+
+class FireLabeler:
+    """Automatically labelize WildFire dataset based on video descriptions
+
+    It will create a new column containing Fire ids that try to identify the videos
+    illustrating same real fire.
+
+    An instance of the Labeler is bound to a dataframe but can be
+    run several times, in order to vary the window size for instance.
+
+    Parameters
+    ----------
+    df: pandas.DataFrame
+        This DataFrame should:
+            - be indexed from 0 to (max number of videos-1) (range-like)
+            - contain the video descriptions in the uploading order.
+                The closer the upload, the more likely videos represent same fire
+            - have a column named 'description' containing the description of the videos
+
+    window_size: in (default=10)
+        Count of video descriptions to use to determine if they represent same fire.
+
+    Attributes
+    ----------
+    n_videos_total: int
+        Count of videos (rows found in dataframe)
+
+    n_windows: int
+        Count of windows
+
+    _n_singletons: int >= 0
+        Count of videos not grouped with at least one other
+        Learnt attribute, available after run()
+
+    Examples
+    --------
+    df = pd.read_csv("WildFire.csv", index_col=0)
+    fire_labeler = FireLabeler(df, window_size=30)
+    fire_labeler.run()
+    df_on_fire = fire_labeler.get_new_dataframe(column_name='fire_id')
+
+    df_on_fire_short = (fire_labeler.reset(window_size=6)
+                                    .run()
+                                    .get_dataframe(column_name='fire_id'))
+    """
+    def __init__(self, df, window_size=10):
+        self.df = df
+        self.window_size = window_size
+
+        self.reset()
+
+    def reset(self, window_size=None):
+        """Reset the labeler
+        Reset fire ids previously found(if any) and set again all dimensions
+        Especially useful, if we want to try another window size"""
+        self.window_size = window_size or self.window_size
+
+        self.n_videos_total = self.df.shape[0]
+        self.n_windows = self.n_videos_total - self.window_size + 1 # n_windows + windows_size < n_videos_total
+
+        # Store new column for fire ids starting at 0 (-1 for unassigned)
+        self.fire_ids = np.full((self.n_videos_total), -1)
+        return self
+
+    def run(self):
+        """ Run the labelisation of the fire depending on the descriptions
+
+        For every combination of descriptions(strings) in every sliding window
+        guess if they belong to same fire (fire_id)
+
+        Note: algo complexity can be improved (ex: by memoizing sliding combinations).
+        But, for now, processing is fast enough(<1min) when used with large window-size<100
+        """
+
+        # sliding iterator over the video indexes. Example with window_size=4:
+        # [[0, 1, 2, 3], [1, 2, 3, 4], [2, 3, 4, 5], ...]
+        window_idx_it = (range(start, start+self.window_size) for start in range(self.n_windows))
+
+        current_fire_id = 0 # start grouping feu id at 0
+        for window_idx in window_idx_it: # for every window of videos
+
+            # dict with {id: description(string)}
+            id_to_descriptions = dict(zip(window_idx, self.df.loc[window_idx, 'description']))
+
+            # for every possible couple of descriptions in the current window
+            for id_s1, id_s2 in combinations(id_to_descriptions, 2):
+                fire_match = self.fire_are_matching(id_to_descriptions[id_s1],
+                                                    id_to_descriptions[id_s2])
+                if fire_match:
+                    # if s1 or s2 has already a fire_id, assign it
+                    if self.fire_ids[id_s1] != -1:
+                        self.fire_ids[id_s2] = self.fire_ids[id_s1]
+                    elif self.fire_ids[id_s2] != -1:
+                        self.fire_ids[id_s1] = self.fire_ids[id_s2]
+                    else: # else we add new fire_id (first encounter)
+                        self.fire_ids[id_s1] = current_fire_id
+                        self.fire_ids[id_s2] = current_fire_id
+                        current_fire_id = current_fire_id + 1
+
+        # Now labeling the singletons
+        self._n_singletons = -1*self.fire_ids[self.fire_ids==-1].sum()
+
+        length = len(self.fire_ids[self.fire_ids==-1])
+        self.fire_ids[self.fire_ids==-1] = range(current_fire_id, current_fire_id+length)
+        assert self.fire_ids[self.fire_ids==-1].sum() == 0, "Singletons escaped indexation!!"
+        return self
+
+    @staticmethod
+    def fire_are_matching(s1, s2):
+        """Compare two fire videos descriptions and guess if they match"""
+
+        # regexp catching fire name (ex: Goose Fire)
+        p = re.compile(r"(?P<firename>\w+\sFire)") # compile once
+        def get_firename(string):
+            """try to extract fire name"""
+            result = p.search(string)
+            if result is not None:
+                return result.group('firename')
+            return None
+
+        firename_s1 = get_firename(s1)
+        firename_s2 = get_firename(s2)
+
+        # Conditions:
+        # - We need to find at least one firename to compare descriptions(!=None)
+        # - if same fire names found, it's a match.
+        # - if 'Glen Fire' is found and 'Glen' is also found, it's a match
+        # - if 'King Fire' is found and 'KingFire' as well, it's a match
+        firenames_match = (firename_s1 is not None
+                               and ((firename_s1 == firename_s2)
+                                    or firename_s1.split(' ')[0] in s2
+                                    or firename_s1.replace(' ','') in s2
+                                   )
+                          ) or (
+                            firename_s2 is not None
+                               and ((firename_s1 == firename_s2)
+                                    or firename_s2.split(' ')[0] in s1
+                                    or firename_s2.replace(' ','') in s1
+                                   )
+                          )
+
+        return firenames_match
+
+    def get_dataframe(self, column_name='fire_id'):
+        """Return the new dataframe complemented with a column(Series) containing the Fire ids"""
+        self.df[column_name] = self.fire_ids
+        return self.df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pandas>=0.25.2
 torch>=1.2.0
 torchvision>=0.4.0
 tqdm>=4.20.0

--- a/test/test_datasets_wildfire.py
+++ b/test/test_datasets_wildfire.py
@@ -10,7 +10,8 @@ from pyronear.datasets.wildfire import FireLabeler
 
 class FireLabelerTester(unittest.TestCase):
 
-    def get_unique_only_count(self, list_):
+    @staticmethod
+    def get_unique_only_count(list_):
         """return count of unique-only elements
         [0, 9, 9, 9, 2, 3, 5, 5] ---> 3
         """

--- a/test/test_datasets_wildfire.py
+++ b/test/test_datasets_wildfire.py
@@ -1,0 +1,120 @@
+import unittest
+
+from collections import (namedtuple,
+                         Counter)
+
+import pandas as pd
+
+from pyronear.datasets.wildfire import FireLabeler
+
+
+class FireLabelerTester(unittest.TestCase):
+
+    def get_unique_only_count(self, list_):
+        """return count of unique-only elements
+        [0, 9, 9, 9, 2, 3, 5, 5] ---> 3
+        """
+        return len([element for (element, count) in Counter(list_).items() if count==1])
+
+    def setUp(self):
+
+        # Let's define an immutable structure to set up the fixtures
+        WildFireFixture = namedtuple('WildFireFixture', 'descriptions fire_ids_truth')
+
+        # Now let's write the fixtures
+        wild_voltaire = WildFireFixture(
+                            descriptions="""Small Fire confirmed east of NOAA fire camera at 6:31 PM
+Voltaire Fire 7pm to midnight, June 12th 2018
+4th hour of the Voltaire Fire as it approaches the urban-wildland interface  at 10 PM
+3rd hour of the Voltaire Fire during a growth phase as seen from McClellan at 9 PM
+2nd hour of the Voltaire Fire near Carson City from McClellan Peak at  8 PM
+Fire near Voltaire Canyon  west of Carson City is confirmed on McClellan Peak camera at  7:43 PM
+Leeks Springs camera spins toward early season Rx fire at 11:38 AM""".split('\n'),
+                            fire_ids_truth=[1, 0, 0, 0, 0, 0, 2])
+
+        wild_glen = WildFireFixture(
+                            descriptions="""Smoke from Ralph Incident Fire seen after midnight from Angels Roost  4K camera
+Sierra at Tahoe fire camera points to the Ralph Incident Fire at 5:40 AM
+2nd fire camera points at the Maggie Fire from Midas Peak after 1 PM
+Maggie Fire caught shortly after Noon from Jacks Peak fire camera
+3rd hour of Glen Fire
+2nd hour of Glen Fire
+6 hour time lapse of "Glen" fire from fire camera located at Sierra at Tahoe
+Start of Glen Fire off of Pioneer Trail seen from Sierra at Tahoe fire camera at 1AM
+NOAA fire camera captures smoke plume associated with crash of Beechcraft airplane
+Small fire is seen near  South Tahoe High School at 2:51 PM
+Flames from the Triple Fire are seen moving closer to ranch as recorded from Jacks 3 PM
+Triple Fire spotted from the Jacks Peak fire camera at 2 PM
+Jacks Peak's fire camera points to River Ranch Fire towards the SE at 2 PM""".split('\n'),
+                            fire_ids_truth= [0, 0, 1, 1, 2, 2, 2, 2, 4, 5, 3, 3, 6])
+
+        wild_king_fire = WildFireFixture(
+                            descriptions="""Zoom to Controlled Burn, Rubicon Oct. 17th, 2014
+King Fire, nighttime from Snow Valley Peak, 8 PM Sept. 17th, 2014
+King Fire, nighttime from CTC North Tahoe, 8 PM Sept. 17th, 2014
+King Fire at sunset from Angel's Roost–Heavenly, 7 PM Sept. 17th, 2014
+King Fire at sunset from CTC North Tahoe, 7 PM Sept. 17th, 2014
+King Fire at sunset from Snow Valley Peak, 7 PM Sept. 17th, 2014
+Cascade Fire from Heavenly 2014 09 24-25
+Cascade Fire from SnowValley 2014 09 24-25
+Rolling blankets of cloud over Tahoe.
+A Heavenly View from Angel's Roost.
+Snow Lake smoke as seen from Heavenly Fire Camera
+Here comes the rain ...
+KingFire view from SnowValley,  The promise of rain ....
+Heavenly 20140924 1600-1900 Smoke from Snow Lake Fire near Cascade Lake seen near sunset
+Heavenly 20140923 1300 1500
+Dense smoke from King Fire chokes NW Tahoe.
+KingFire Saturday 09/20, view from East Lake Tahoe.
+Shifting high winds bring the King Fire back to life with smoke rolling back into South Lake Tahoe.
+Smoke from the King Fire engulfs Tahoe South Shore
+KingFire SnowValley 20140917 14:00-22:00
+KingFire CTC 20140917 13:00-22:00
+KingFire Heavenly 20140917 12:00-20:00
+Near-Infrared Night Video of KingFire SnowValley 20140916 23:00-04:00
+KingFire Heavenly 20140916 15:00-19:00
+KingFire SnowValley 20140916 15:00-18:00
+KingFire Heavenly 20140916 11:40-15:00
+KingFire CTC 20140916 11:40-15:00
+KingFire SnowValley 20140916 12:30-15:00
+King Fire Heavenly 20140915 14:32-15:00
+King Fire Heavenly 20140915
+Bison Fire 2013-07-09 x25 Time Lapse
+Bison Fire 2013-07-08 x25 Time Lapse
+Bison Fire 2013-07-07 x25 Time Lapse
+Bison Fire 2013-07-06 x25 Time Lapse
+Bison Fire 2013-07-05 x25 Time Lapse""".split('\n'),
+                            fire_ids_truth = [3, 0, 0, 0, 0, 0, 1, 1, 4, 1,
+                                              1, 5, 0, 1, 1, 0, 0, 0, 0, 0,
+                                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                              2, 2, 2, 2, 2])
+
+        self.fixtures = [wild_voltaire, wild_glen]
+        self.fixtures_long = [wild_king_fire]
+
+    def test_label_correctly_short_dependency(self):
+        for (descriptions, fire_ids_truth) in self.fixtures:
+            df = pd.DataFrame({'description': descriptions})
+
+            fire_labeler = FireLabeler(df, window_size=3)
+            fire_labeler.run()
+            df = fire_labeler.get_dataframe(column_name='fire_id')
+            self.assertListEqual(df['fire_id'].tolist(), fire_ids_truth)
+            self.assertEqual(fire_labeler._n_singletons, self.get_unique_only_count(fire_ids_truth))
+
+
+    def test_label_correctly_long_dependency(self):
+        """Test if descriptions are correctly gathered if they are far from each other.
+        While keeping in mind videos are ordered in time"""
+        for (descriptions, fire_ids_truth) in self.fixtures_long:
+            df = pd.DataFrame({'description': descriptions})
+
+            fire_labeler = FireLabeler(df, window_size=30)
+            fire_labeler.run()
+            df = fire_labeler.get_dataframe(column_name='fire_id')
+            self.assertListEqual(df['fire_id'].tolist(), fire_ids_truth)
+            self.assertEqual(fire_labeler._n_singletons, self.get_unique_only_count(fire_ids_truth))
+
+
+if __name__ == '__main__':
+    unittest.main(FireLabelerTester())

--- a/test/test_datasets_wildfire.py
+++ b/test/test_datasets_wildfire.py
@@ -14,7 +14,7 @@ class FireLabelerTester(unittest.TestCase):
         """return count of unique-only elements
         [0, 9, 9, 9, 2, 3, 5, 5] ---> 3
         """
-        return len([element for (element, count) in Counter(list_).items() if count==1])
+        return len([element for (element, count) in Counter(list_).items() if count == 1])
 
     def setUp(self):
 
@@ -22,18 +22,16 @@ class FireLabelerTester(unittest.TestCase):
         WildFireFixture = namedtuple('WildFireFixture', 'descriptions fire_ids_truth')
 
         # Now let's write the fixtures
-        wild_voltaire = WildFireFixture(
-                            descriptions="""Small Fire confirmed east of NOAA fire camera at 6:31 PM
+        wild_voltaire = WildFireFixture(descriptions="""Small Fire confirmed east of NOAA fire camera at 6:31 PM
 Voltaire Fire 7pm to midnight, June 12th 2018
 4th hour of the Voltaire Fire as it approaches the urban-wildland interface  at 10 PM
 3rd hour of the Voltaire Fire during a growth phase as seen from McClellan at 9 PM
 2nd hour of the Voltaire Fire near Carson City from McClellan Peak at  8 PM
 Fire near Voltaire Canyon  west of Carson City is confirmed on McClellan Peak camera at  7:43 PM
 Leeks Springs camera spins toward early season Rx fire at 11:38 AM""".split('\n'),
-                            fire_ids_truth=[1, 0, 0, 0, 0, 0, 2])
+                                        fire_ids_truth=[1, 0, 0, 0, 0, 0, 2])
 
-        wild_glen = WildFireFixture(
-                            descriptions="""Smoke from Ralph Incident Fire seen after midnight from Angels Roost  4K camera
+        wild_glen = WildFireFixture(descriptions="""Smoke from Ralph Incident Fire seen after midnight from Angels Roost  4K camera
 Sierra at Tahoe fire camera points to the Ralph Incident Fire at 5:40 AM
 2nd fire camera points at the Maggie Fire from Midas Peak after 1 PM
 Maggie Fire caught shortly after Noon from Jacks Peak fire camera
@@ -46,10 +44,9 @@ Small fire is seen near  South Tahoe High School at 2:51 PM
 Flames from the Triple Fire are seen moving closer to ranch as recorded from Jacks 3 PM
 Triple Fire spotted from the Jacks Peak fire camera at 2 PM
 Jacks Peak's fire camera points to River Ranch Fire towards the SE at 2 PM""".split('\n'),
-                            fire_ids_truth= [0, 0, 1, 1, 2, 2, 2, 2, 4, 5, 3, 3, 6])
+                                    fire_ids_truth=[0, 0, 1, 1, 2, 2, 2, 2, 4, 5, 3, 3, 6])
 
-        wild_king_fire = WildFireFixture(
-                            descriptions="""Zoom to Controlled Burn, Rubicon Oct. 17th, 2014
+        wild_king_fire = WildFireFixture(descriptions="""Zoom to Controlled Burn, Rubicon Oct. 17th, 2014
 King Fire, nighttime from Snow Valley Peak, 8 PM Sept. 17th, 2014
 King Fire, nighttime from CTC North Tahoe, 8 PM Sept. 17th, 2014
 King Fire at sunset from Angel's Roost–Heavenly, 7 PM Sept. 17th, 2014
@@ -84,10 +81,10 @@ Bison Fire 2013-07-08 x25 Time Lapse
 Bison Fire 2013-07-07 x25 Time Lapse
 Bison Fire 2013-07-06 x25 Time Lapse
 Bison Fire 2013-07-05 x25 Time Lapse""".split('\n'),
-                            fire_ids_truth = [3, 0, 0, 0, 0, 0, 1, 1, 4, 1,
-                                              1, 5, 0, 1, 1, 0, 0, 0, 0, 0,
-                                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                              2, 2, 2, 2, 2])
+                                         fire_ids_truth=[3, 0, 0, 0, 0, 0, 1, 1, 4, 1,
+                                                         1, 5, 0, 1, 1, 0, 0, 0, 0, 0,
+                                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                         2, 2, 2, 2, 2])
 
         self.fixtures = [wild_voltaire, wild_glen]
         self.fixtures_long = [wild_king_fire]
@@ -101,7 +98,6 @@ Bison Fire 2013-07-05 x25 Time Lapse""".split('\n'),
             df = fire_labeler.get_dataframe(column_name='fire_id')
             self.assertListEqual(df['fire_id'].tolist(), fire_ids_truth)
             self.assertEqual(fire_labeler._n_singletons, self.get_unique_only_count(fire_ids_truth))
-
 
     def test_label_correctly_long_dependency(self):
         """Test if descriptions are correctly gathered if they are far from each other.
@@ -130,6 +126,7 @@ Bison Fire 2013-07-05 x25 Time Lapse""".split('\n'),
         s1 = "2nd hour of Glen Fire"
         s2 = '6 hour time lapse of "Glen" fire from fire camera located at Sierra at Tahoe'
         self.assertTrue(FireLabeler.fire_are_matching(s1, s2))
+
 
 if __name__ == '__main__':
     unittest.main(FireLabelerTester())

--- a/test/test_datasets_wildfire.py
+++ b/test/test_datasets_wildfire.py
@@ -115,6 +115,21 @@ Bison Fire 2013-07-05 x25 Time Lapse""".split('\n'),
             self.assertListEqual(df['fire_id'].tolist(), fire_ids_truth)
             self.assertEqual(fire_labeler._n_singletons, self.get_unique_only_count(fire_ids_truth))
 
+    def test_firenames_matching(self):
+        # It should be robust to space before Fire 'King Fire' & 'KingFire':
+        s1 = "King Fire Heavenly 20140915 14:32-15:00"
+        s2 = "KingFire SnowValley 20140916 12:30-15:00"
+        self.assertTrue(FireLabeler.fire_are_matching(s1, s2))
+
+        # If Fire name is hidden in the sentence, it should be a match
+        s1 = "Smoke from the King Fire engulfs Tahoe South Shore"
+        s2 = "KingFire SnowValley 20140916 12:30-15:00"
+        self.assertTrue(FireLabeler.fire_are_matching(s1, s2))
+
+        # if fire name is found without being suffixed by Fire, it should match
+        s1 = "2nd hour of Glen Fire"
+        s2 = '6 hour time lapse of "Glen" fire from fire camera located at Sierra at Tahoe'
+        self.assertTrue(FireLabeler.fire_are_matching(s1, s2))
 
 if __name__ == '__main__':
     unittest.main(FireLabelerTester())


### PR DESCRIPTION
This PR aims at adding a auto fire labeling feature to the WildFire dataset.

The new `FireLabeler` class tries to group the videos representing the same fire. Labeling is based on words in descriptions of the videos. It looks for commonalities through a sliding window with a size one can vary representing the depth of the search.

This PR also create a `wildfire` directory in `datasets` module. I suggest to group in this directory the growing number of tools we are currently developing to preprocess this dataset.

Here is an example:

```python
df = pd.read_csv("WildFire.csv", index_col=0)
fire_labeler = FireLabeler(df, window_size=30)
fire_labeler.run()
df_on_fire = fire_labeler.get_new_dataframe(column_name='fire_id')

df_on_fire_short = (fire_labeler.reset(window_size=6)
                                .run()
                                .get_dataframe(column_name='fire_id'))
```
For more example, one can browse unit and integration tests.
Any feedback is welcome.
