### PR TITLE
docs: Added WildFireDataset to the documentation

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -16,5 +16,12 @@ The following datasets are available:
 
 OpenFire
 ~~~~~~~~
+An image classification dataset for wildfire in natural environments, built using Google Images referenced data.
 
 .. autoclass:: OpenFire
+
+WildFire
+~~~~~~~~
+A video dataset labeled with spatio-temporal keypoints for wilfire detection, built using available surveillance camera data.
+
+.. autoclass:: WildFireDataset

--- a/pyronear/datasets/__init__.py
+++ b/pyronear/datasets/__init__.py
@@ -1,2 +1,3 @@
 from .openfire import OpenFire
+from .wildfire import WildFireDataset
 from . import utils


### PR DESCRIPTION
This PR aims at:
- adding `WildFireDataset` to the  `pyronear.datasets.__init__.py` so it can be imported more easily
- adding `WildFireDataset` to the documentation as it was not added to the sphinx source folder (cf. below)

![wildfire_docs](https://user-images.githubusercontent.com/26927750/79693682-6ae9af80-826c-11ea-8d94-80f330624a85.png)


_Any feedback is welcome!_