### PR TITLE
Type correction in WildFireDataset

### DIFF
--- a/pyronear/datasets/wildfire/wildfire.py
+++ b/pyronear/datasets/wildfire/wildfire.py
@@ -71,7 +71,7 @@ class WildFireDataset(Dataset, VisionMixin):
         Non-exhaustive values that can be found in self.target_names:
             ['fire', 'clf_confidence', 'loc_confidence', 'x', 'y']
         """
-        return torch.from_numpy(self.metadata[self.target_names].iloc[index].values)
+        return torch.from_numpy(self.metadata[self.target_names].iloc[index].values.astype(float))
 
 
 class WildFireSplitter:


### PR DESCRIPTION
This quick update allows to avoid the following error :

TypeError: can't convert np.ndarray of type numpy.object_. The only supported types are: float64, float32, float16, int64, int32, int16, int8, uint8, and bool.