### PR TITLE
Allow test ratio to zero in WildFireSplitter

### DIFF
--- a/pyronear/datasets/wildfire/split_strategy.py
+++ b/pyronear/datasets/wildfire/split_strategy.py
@@ -72,7 +72,8 @@ class ExhaustSplitStrategy(SplitStrategy):
         if ratios['test'] > 0:
             fire_ids = {'train': self._get_fire_ids_for_one_split(n_samples_train),
                         'val': self._get_fire_ids_for_one_split(n_samples_val)}
-            fire_ids['test'] = [id_ for id_ in self._fire_id_to_size if id_ not in (fire_ids['train'] + fire_ids['val'])]
+            fire_ids['test'] = [id_ for id_ in self._fire_id_to_size
+                                if id_ not in (fire_ids['train'] + fire_ids['val'])]
             # Finish exhaustion
             for fire_id_test in fire_ids['test']:
                 del self._fire_id_to_size_to_exhaust[fire_id_test]
@@ -83,7 +84,7 @@ class ExhaustSplitStrategy(SplitStrategy):
             # Finish exhaustion
             for fire_id_test in fire_ids['val']:
                 del self._fire_id_to_size_to_exhaust[fire_id_test]
-            fire_ids['test']=[]
+            fire_ids['test'] = []
 
         n_samples_remaining = len(self._fire_id_to_size_to_exhaust)
         if n_samples_remaining != 0:

--- a/pyronear/datasets/wildfire/split_strategy.py
+++ b/pyronear/datasets/wildfire/split_strategy.py
@@ -69,12 +69,21 @@ class ExhaustSplitStrategy(SplitStrategy):
         self._fire_id_to_size_to_exhaust = copy.deepcopy(self._fire_id_to_size)
 
         # Let's get
-        fire_ids = {'train': self._get_fire_ids_for_one_split(n_samples_train),
-                    'val': self._get_fire_ids_for_one_split(n_samples_val)}
-        fire_ids['test'] = [id_ for id_ in self._fire_id_to_size if id_ not in (fire_ids['train'] + fire_ids['val'])]
-        # Finish exhaustion
-        for fire_id_test in fire_ids['test']:
-            del self._fire_id_to_size_to_exhaust[fire_id_test]
+        if ratios['test'] > 0:
+            fire_ids = {'train': self._get_fire_ids_for_one_split(n_samples_train),
+                        'val': self._get_fire_ids_for_one_split(n_samples_val)}
+            fire_ids['test'] = [id_ for id_ in self._fire_id_to_size if id_ not in (fire_ids['train'] + fire_ids['val'])]
+            # Finish exhaustion
+            for fire_id_test in fire_ids['test']:
+                del self._fire_id_to_size_to_exhaust[fire_id_test]
+
+        else:
+            fire_ids = {'train': self._get_fire_ids_for_one_split(n_samples_train)}
+            fire_ids['val'] = [id_ for id_ in self._fire_id_to_size if id_ not in fire_ids['train']]
+            # Finish exhaustion
+            for fire_id_test in fire_ids['val']:
+                del self._fire_id_to_size_to_exhaust[fire_id_test]
+            fire_ids['test']=[]
 
         n_samples_remaining = len(self._fire_id_to_size_to_exhaust)
         if n_samples_remaining != 0:

--- a/pyronear/datasets/wildfire/wildfire.py
+++ b/pyronear/datasets/wildfire/wildfire.py
@@ -158,10 +158,10 @@ class WildFireSplitter:
         """
         self.wildfire = wildfire
         # Some checks first
-        if wildfire.metadata['fire_id'].nunique() != wildfire.metadata['fire_id'].max() + 1:
-            warnings.warn(f"Inconsistent Fire Labeling. Maybe try to label the fire again\n"
-                          f"Distinct values of ids({wildfire.metadata['fire_id'].nunique()}"
-                          f" ≠ {wildfire.metadata['fire_id'].max() + 1})", Warning)
+        # if wildfire.metadata['fire_id'].nunique() != wildfire.metadata['fire_id'].max() + 1:
+        #     warnings.warn(f"Inconsistent Fire Labeling. Maybe try to label the fire again\n"
+        #                   f"Distinct values of ids({wildfire.metadata['fire_id'].nunique()}"
+        #                   f" ≠ {wildfire.metadata['fire_id'].max() + 1})", Warning)
 
         if self.algorithm != 'auto':
             raise ValueError(f"Algorithm {self.algorithm} is unknown. Only 'auto' available for now")

--- a/pyronear/datasets/wildfire/wildfire.py
+++ b/pyronear/datasets/wildfire/wildfire.py
@@ -157,7 +157,7 @@ class WildFireSplitter:
         Because split is randomly done
         """
         self.wildfire = wildfire
-        #Some checks first
+        # Some checks first
         if wildfire.metadata['fire_id'].nunique() != wildfire.metadata['fire_id'].max() + 1:
             warnings.warn(f"Inconsistent Fire Labeling. Maybe try to label the fire again\n"
                           f"Distinct values of ids({wildfire.metadata['fire_id'].nunique()}"

--- a/pyronear/datasets/wildfire/wildfire.py
+++ b/pyronear/datasets/wildfire/wildfire.py
@@ -157,11 +157,11 @@ class WildFireSplitter:
         Because split is randomly done
         """
         self.wildfire = wildfire
-        # Some checks first
-        # if wildfire.metadata['fire_id'].nunique() != wildfire.metadata['fire_id'].max() + 1:
-        #     warnings.warn(f"Inconsistent Fire Labeling. Maybe try to label the fire again\n"
-        #                   f"Distinct values of ids({wildfire.metadata['fire_id'].nunique()}"
-        #                   f" ≠ {wildfire.metadata['fire_id'].max() + 1})", Warning)
+        #Some checks first
+        if wildfire.metadata['fire_id'].nunique() != wildfire.metadata['fire_id'].max() + 1:
+            warnings.warn(f"Inconsistent Fire Labeling. Maybe try to label the fire again\n"
+                          f"Distinct values of ids({wildfire.metadata['fire_id'].nunique()}"
+                          f" ≠ {wildfire.metadata['fire_id'].max() + 1})", Warning)
 
         if self.algorithm != 'auto':
             raise ValueError(f"Algorithm {self.algorithm} is unknown. Only 'auto' available for now")

--- a/test/test_datasets_wildfire_split.py
+++ b/test/test_datasets_wildfire_split.py
@@ -88,6 +88,11 @@ class WildFireDatasetSplitter(unittest.TestCase):
         splitter = WildFireSplitter(ratios)
         self.assertEqual(ratios, splitter.ratios)
 
+    def test_consistent_ratios_good_init_with_test_to_zero(self):
+        ratios = {'train': 0.8, 'val': 0.2, 'test': 0}
+        splitter = WildFireSplitter(ratios)
+        self.assertEqual(ratios, splitter.ratios)
+
     def test_inconsistent_ratios_raise_exception(self):
         ratios = {'train': 0.9, 'val': 0.2, 'test': 0.1}  # sum > 1
         with self.assertRaises(ValueError):

--- a/test/test_datasets_wildfire_split.py
+++ b/test/test_datasets_wildfire_split.py
@@ -88,15 +88,19 @@ class WildFireDatasetSplitter(unittest.TestCase):
         splitter = WildFireSplitter(ratios)
         self.assertEqual(ratios, splitter.ratios)
 
-    def test_consistent_ratios_good_init_with_test_to_zero(self):
-        ratios = {'train': 0.8, 'val': 0.2, 'test': 0}
-        splitter = WildFireSplitter(ratios)
-        self.assertEqual(ratios, splitter.ratios)
-
     def test_inconsistent_ratios_raise_exception(self):
         ratios = {'train': 0.9, 'val': 0.2, 'test': 0.1}  # sum > 1
         with self.assertRaises(ValueError):
             WildFireSplitter(ratios)
+
+    def test_splitting_with_test_to_zero(self):
+        ratios = {'train': 0.81, 'val': 0.19, 'test': 0}
+
+        splitter = WildFireSplitter(ratios, seed=42)
+        splitter.fit(self.wildfire)
+
+        for (set_, ratio_) in splitter.ratios_.items():
+            self.assertAlmostEqual(ratio_, ratios[set_], places=2)
 
     def test_splitting_gives_good_splits_size(self):
         n_samples_expected = {'train': 684, 'val': 147, 'test': 143}


### PR DESCRIPTION
This PR aims to answer the issue : [DataSet] Allow test ratio to zero in WildFireSplitter #61

As explain in the issue :

At the moment the input ratios of WildFireSplitter cannot be equal to zero. I would like to add this option. Indeed we are going to do a lot of tests with different extraction methods (number of frames, spacing between frames ...). As the frame extraction is long I think we will save a lot of time if we don't have to do it every time for the test set.

PS: I have also commented the warinig

```
"Labeling. Maybe try to label the fire again
Distinct values of ids(340 ≠ 420)
f" ≠ {wildfire.metadata['fire_id'].max() + 1})", Warning)"
```

We haven't annotated the entire Dataset so we're going to get this warning every time.