### PR TITLE
Add markdown broken links checker in CI

### DIFF
--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,5 +1,7 @@
 {
     "ignorePatterns": [
-        { "pattern": "^https://github.com/YOUR_USERNAME" }
+        {
+          "pattern": "^https://github.com/YOUR_USERNAME"
+        }
     ]
 }

--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -1,0 +1,5 @@
+{
+    "ignorePatterns": [
+        { "pattern": "^https://github.com/YOUR_USERNAME" }
+    ]
+}

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,13 @@
+name: Check Broken Markdown Links
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@master

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -11,3 +11,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@master
+      with:
+        config-file: 'markdown-links-config.json'

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -12,4 +12,4 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@master
       with:
-        config-file: 'markdown-links-config.json'
+        config-file: '.github/workflows/markdown-links-config.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,13 @@ As a contributor, you will only have to ensure coverage of your code by adding a
 
 
 
-## Issues
+## Issues
 
 Use Github [issues](https://github.com/frgfm/PyroNear/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
 
 
 
-## Code contribution
+## Code contribution
 
 In order to contribute to  project, we will first **set up the development environment**, then describe the **contributing workflow**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,12 @@ Use Github [issues](https://github.com/frgfm/PyroNear/issues) for feature reques
 
 In order to contribute to  project, we will first **set up the development environment**, then describe the **contributing workflow**.
 
-* [Project Setup](project-setup)
+* [Project Setup](#project-setup)
 
     _How to set up a forked project and install its dependencies in a well-encapsulated development environment_
     1. [Create a virtual environment](#create-a-virtual-environment)
     2. [Fork the project](#fork-the-repository)
-* [Contributing workflow](contributing-workflow)
+* [Contributing workflow](#contributing-workflow)
 
    _How to pull remote changes/new contributions and push your contributions to the original project_
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ python references/classification/fastai/train.py --lr 3e-3 --epochs 4 --pretrain
 
 ## Documentation
 
-The full package documentation is available [here](<https://frgfm.github.io/PyroNear/>) for detailed specifications. The documentation was built with [Sphinx](sphinx-doc.org) using a [theme](github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](readthedocs.org).
+The full package documentation is available [here](<https://frgfm.github.io/PyroNear/>) for detailed specifications. The documentation was built with [Sphinx](https://www.sphinx-doc.org) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org).
 
 
 


### PR DESCRIPTION
This PR add a job in the CI that automatically check if the links in the markdown are still valid when opening a PR on `master`.
This way, we help us and other to have a documentation still working.

[Official doc](https://github.com/marketplace/actions/markdown-link-check#custom-variables)

Application on actual version of CONTRIBUTING:
```
=========================> MARKDOWN LINK CHECK <=========================

FILE: ./CONTRIBUTING.md
[✓] https://github.com/frgfm/PyroNear/blob/master/pyronear
[✓] https://github.com/frgfm/PyroNear/blob/master/references
[✓] https://github.com/frgfm/PyroNear/blob/master/test
[✓] https://circleci.com/
[✓] https://www.codacy.com/
[✓] https://codecov.io/
[✓] https://github.com/frgfm/PyroNear/issues
[✖] project-setup
[✓] #create-a-virtual-environment
[✓] #fork-the-repository
[✖] contributing-workflow
[✓] #commits
[✓] https://virtualenvwrapper.readthedocs.io/
[✖] https://github.com/YOUR_USERNAME/PyroNear.git
[✓] https://help.github.com/en/articles/creating-a-pull-request-from-a-fork
[✓] https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
[✓] http://udacity.github.io/git-styleguide/

17 links checked.

ERROR: 3 dead links found!
[✖] project-setup → Status: 400
[✖] contributing-workflow → Status: 400
[✖] https://github.com/YOUR_USERNAME/PyroNear.git → Status: 404
```
