### PR TITLE
chore: Ensure squashed merged PR triggers workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: python-package
 
 on:
-  pull_request
+  pull_request:
+    branches:
+      - master
   push:
     branches:
       - master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: python-package
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   pkg-install:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: python-package
 
-on: [push, pull_request]
+on:
+  pull_request
+  push:
+    branches:
+      - master
 
 jobs:
   pkg-install:


### PR DESCRIPTION
Currently, PR trigger the main workflow, but once the commits are squash-merged into master, the workflow do not run again.

This PR enforces workflow trigger on squash merged commits into master.