### PR TITLE
docs: Updated docs following up on repo transfer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,12 +28,12 @@ Steps to reproduce the behavior:
 ## Environment
 
 Please copy and paste the output from our
-[environment collection script](https://raw.githubusercontent.com/frgfm/PyroNear/master/pyronear/utils/collect_env.py)
+[environment collection script](https://raw.githubusercontent.com/pyronear/PyroNear/master/pyronear/utils/collect_env.py)
 (or fill out the checklist below manually).
 
 You can get the script and run it with:
 ```
-wget https://raw.githubusercontent.com/frgfm/PyroNear/master/pyronear/utils/collect_env.py
+wget https://raw.githubusercontent.com/pyronear/PyroNear/master/pyronear/utils/collect_env.py
 # For security purposes, please check the contents of collect_env.py before running it.
 python collect_env.py
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ Everything you need to know to contribute efficiently to the project.
 
 ## Codebase structure
 
-- [pyronear](https://github.com/frgfm/PyroNear/blob/master/pyronear) - The actual PyroNear library
-- [references](https://github.com/frgfm/PyroNear/blob/master/references) - Scripts to reproduce performances
-- [test](https://github.com/frgfm/PyroNear/blob/master/test) - Python unit tests
+- [pyronear](https://github.com/pyronear/PyroNear/blob/master/pyronear) - The actual PyroNear library
+- [references](https://github.com/pyronear/PyroNear/blob/master/references) - Scripts to reproduce performances
+- [test](https://github.com/pyronear/PyroNear/blob/master/test) - Python unit tests
 
 
 
@@ -26,7 +26,7 @@ As a contributor, you will only have to ensure coverage of your code by adding a
 
 ## Issues
 
-Use Github [issues](https://github.com/frgfm/PyroNear/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
+Use Github [issues](https://github.com/pyronear/PyroNear/issues) for feature requests, or bug reporting. When doing so, use issue templates whenever possible and provide enough information for other contributors to jump in.
 
 
 
@@ -100,7 +100,7 @@ cd PyroNear
 3. Set remotes to original project and merge new contributions onto master.
 ```shell
 # add the original repository as remote repository called "upstream"
-git remote add upstream https://github.com/frgfm/PyroNear.git
+git remote add upstream https://github.com/pyronear/PyroNear.git
 
 # verify repository has been correctly added
 git remote -v

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python references/classification/fastai/train.py --lr 3e-3 --epochs 4 --pretrain
 
 ## Documentation
 
-The full package documentation is available [here](<https://pyronear.github.io/PyroNear/>) for detailed specifications. The documentation was built with [Sphinx](sphinx-doc.org) using a [theme](github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](readthedocs.org).
+The full package documentation is available [here](https://pyronear.github.io/PyroNear/) for detailed specifications. The documentation was built with [Sphinx](sphinx-doc.org) using a [theme](github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](readthedocs.org).
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 <p align="center">
     <a href="LICENSE" alt="License">
         <img src="https://img.shields.io/badge/License-MIT-brightgreen.svg" /></a>
-    <a href="https://www.codacy.com/manual/fg/pyronear?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=frgfm/PyroNear&amp;utm_campaign=Badge_Grade">
-        <img src="https://api.codacy.com/project/badge/Grade/55423de221b14b18a5e35804574d5d5a"/></a>
-    <a href="https://circleci.com/gh/frgfm/PyroNear">
-        <img src="https://circleci.com/gh/frgfm/PyroNear.svg?style=shield" /></a>
-    <a href="https://codecov.io/gh/frgfm/PyroNear">
-  		<img src="https://codecov.io/gh/frgfm/PyroNear/branch/master/graph/badge.svg" /></a>
-    <a href="https://frgfm.github.io/PyroNear">
+    <a href="https://www.codacy.com/manual/frgfm/pyronear?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pyronear/PyroNear&amp;utm_campaign=Badge_Grade">
+        <img src="https://app.codacy.com/project/badge/Grade/55423de221b14b18a5e35804574d5d5a"/></a>
+    <a href="https://github.com/pyronear/PyroNear/actions?query=workflow%3Apython-package">
+        <img src="https://github.com/pyronear/PyroNear/workflows/python-package/badge.svg" /></a>
+    <a href="https://codecov.io/gh/pyronear/PyroNear">
+  		<img src="https://codecov.io/gh/pyronear/PyroNear/branch/master/graph/badge.svg" />
+	</a>
+    <a href="https://pyronear.github.io/PyroNear">
   		<img src="https://img.shields.io/badge/docs-available-blue.svg" /></a>
     <a href="https://pypi.org/project/pyronear/" alt="Pypi">
         <img src="https://img.shields.io/badge/pypi-v0.1.0-blue.svg" /></a>
@@ -90,7 +91,7 @@ python references/classification/fastai/train.py --lr 3e-3 --epochs 4 --pretrain
 
 ## Documentation
 
-The full package documentation is available [here](<https://frgfm.github.io/PyroNear/>) for detailed specifications. The documentation was built with [Sphinx](sphinx-doc.org) using a [theme](github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](readthedocs.org).
+The full package documentation is available [here](<https://pyronear.github.io/PyroNear/>) for detailed specifications. The documentation was built with [Sphinx](sphinx-doc.org) using a [theme](github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](readthedocs.org).
 
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python references/classification/fastai/train.py --lr 3e-3 --epochs 4 --pretrain
 
 ## Documentation
 
-The full package documentation is available [here](https://pyronear.github.io/PyroNear/) for detailed specifications. The documentation was built with [Sphinx](https://sphinx-doc.org) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org).
+The full package documentation is available [here](https://pyronear.github.io/PyroNear/) for detailed specifications. The documentation was built with [Sphinx](https://www.sphinx-doc.org) using a [theme](https://github.com/readthedocs/sphinx_rtd_theme) provided by [Read the Docs](https://readthedocs.org).
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
     description='Datasets and models for wildfire detection in PyTorch',
     long_description=readme,
     long_description_content_type="text/markdown",
-    url='https://github.com/frgfm/PyroNear',
-    download_url='https://github.com/frgfm/PyroNear/tags',
+    url='https://github.com/pyronear/PyroNear',
+    download_url='https://github.com/pyronear/PyroNear/tags',
     license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This PR updates URLs following up on repo transfer by:
- updating badges
- updating web page references
- updating repo URL references 