### PR TITLE
chore: Fixed doc deploy

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -35,7 +35,7 @@ jobs:
           sphinx-build docs/source docs/build -a -v
 
       - name: Install SSH Client 🔑
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
 


### PR DESCRIPTION
Since Github deprecated set-env, several actions have to be updated to prevent crashes.

cf. cf. https://github.com/webfactory/ssh-agent/blob/master/CHANGELOG.md#v041-2020-10-07