### PR TITLE
docs: Fixed sphinx requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx<3.5.0
 sphinx-rtd-theme==0.4.3
 pyrovision


### PR DESCRIPTION
This PR simply adds a version constraint on sphinx since the latest release is causing issues. The bug has already been reported but won't be fixes until next release, hence this new constraint.