### PR TITLE
docs: Removed utils from documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,6 @@ for wildfire detection tasks.
    datasets
    models
    nn
-   utils
 
 
 .. automodule:: pyrovision

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,7 +1,0 @@
-pyrovision.utils
-================
-
-.. currentmodule:: pyrovision.utils
-
-.. autofunction:: get_pretty_env_info
-


### PR DESCRIPTION
Following up on #96, this PR removes the utils page in the documentation and its reference in the index.