### PR TITLE
fix: Fixed mobilenet imports for latest torch/torchvision releases

### DIFF
--- a/pyrovision/models/mobilenet.py
+++ b/pyrovision/models/mobilenet.py
@@ -3,7 +3,7 @@
 # This program is licensed under the GNU Affero General Public License version 3.
 # See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
 
-from torchvision.models.mobilenet import MobileNetV2, model_urls as imagenet_urls
+from torchvision.models.mobilenetv2 import MobileNetV2, model_urls as imagenet_urls
 from torchvision.models.utils import load_state_dict_from_url
 from .utils import cnn_model
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python>=3.4.5.20
 pandas>=0.25.2
-torch>=1.2.0
-torchvision>=0.4.0
+torch>=1.8.0
+torchvision>=0.9.0
 tqdm>=4.20.0
 requests>=2.20.0
 pylocron>=0.1.3

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ with open('README.md') as f:
 requirements = [
     'opencv-python>=3.4.5.20',
     'pandas>=0.25.2',
-    'torch>=1.2.0',
-    'torchvision>=0.4.0',
+    'torch>=1.8.0',
+    'torchvision>=0.9.0',
     'tqdm>=4.20.0',
     'requests>=2.20.0',
     'pylocron>=0.1.3',


### PR DESCRIPTION
Try to import mobilenet_v2 `from pyrovision.models.mobilenet import mobilenet_v2` , leed to the following error:

 ImportError: cannot import name 'model_urls' from 'torchvision.models.mobilenet' (/usr/local/lib/python3.7/dist-packages/torchvision/models/mobilenet.py)

This is beacause torchvision has changed, model_urls for mobilenet_v2 is now in `from pyrovision.models.mobilenetv2`

This change was made in the last torchvision release(0.9.0), we need to update the requirements too