### PR TITLE
docs: add inference exemple in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ tf = transforms.Compose([transforms.Resize(size=(448)), transforms.CenterCrop(si
 model = rexnet1_0x(pretrained=True).eval()
 
 # Predict
-im = Image.open("path/to/your/image.jpg").convert('RGB')
-imT = tf(im)
+im = tf(Image.open("path/to/your/image.jpg").convert('RGB'))
 
 with torch.no_grad():
+    pred = model(im.unsqueeze(0))
     is_wildfire = torch.sigmoid(pred).item() >= 0.5
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,21 +89,11 @@ tf = transforms.Compose([transforms.Resize(size=(img_size)),
 model = rexnet1_0x(pretrained=True).eval()
 
 # Predict
-im_file = 'im.jpg'
-im = Image.open(im_file).convert('RGB')
+im = Image.open("path/to/your/image.jpg").convert('RGB')
 imT = tf(im)
 
 with torch.no_grad():
-    pred = model(imT.unsqueeze(0))
-    pred = torch.sigmoid(pred).item()
-    
-if pred < 0.5:
-    print("No fire detected. Fire probability: {:.2%}".format(pred))
-else:
-    print("Fire detected! Fire probability: {:.2%}".format(pred))
-```
-
-
+    is_wildfire = torch.sigmoid(pred).item() >= 0.5
 
 ### Docker container
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ imT = tf(im)
 
 with torch.no_grad():
     is_wildfire = torch.sigmoid(pred).item() >= 0.5
+```
+
+
 
 ### Docker container
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,9 @@ from PIL import Image
 
 # Init
 normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-img_size = 448
 
-tf = transforms.Compose([transforms.Resize(size=(img_size)),
-                              transforms.CenterCrop(size=img_size),
-                              transforms.ToTensor(),
-                              normalize
-                              ])
+tf = transforms.Compose([transforms.Resize(size=(448)), transforms.CenterCrop(size=448),
+                         transforms.ToTensor(), normalize])
 
 model = rexnet1_0x(pretrained=True).eval()
 


### PR DESCRIPTION
The readme is missing a clear and simple example to predict if there is fire on a given image

I also move the example of how to use our dataset which was misplaced in the readme
