### PR TITLE
chore: Fixed documentation build and added CI jobs for doc sanity check

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Build documentation
         run: sphinx-build docs/source docs/build -a -v
 
+      - name: Documentation sanity check
+        run: test -e docs/build/index.html || exit
+
       - name: Install SSH Client 🔑
         uses: webfactory/ssh-agent@v0.4.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,3 +124,6 @@ jobs:
 
       - name: Build documentation
         run: sphinx-build docs/source docs/build -a
+
+      - name: Documentation sanity check
+        run: test -e docs/build/index.html || exit

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx<3.5.0
 sphinx-rtd-theme==0.4.3
+docutils<0.18
 pyrovision


### PR DESCRIPTION
This PR introduces the following modifications:
- one of sphinx deps `docutils` recently made a release that crashed new builds, so this adds a version constraint to avoid that latest release
- the documentation build was failing silently, so I added a CI job to ensure that at least the landing page was built properly in HTML

This has solved the issue on other projects of mine.

Any feedback is welcome! 