### PR TITLE
ci: Updated python version for builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.6, 3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Python 3.6 is getting quite old (release in 2016) I think we can delete this test and add python 3.9 instead

[The build test](https://github.com/pyronear/pyro-vision/runs/5176415971?check_suite_focus=true) do not work anymore on mac