### PR TITLE
ignore version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 data/
 test/fixtures/videos/
 conda-dist/
+
+#Ignore version file
+pyrovision/version.py


### PR DESCRIPTION
Because version file if generated from setup, maybe it's cleaner to ignore it to avoid a useless untracked file