### PR TITLE
chore: Bumped pylocron version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "torchvision>=0.12.0,<1.0.0",
     "tqdm>=4.1.0",
     "requests>=2.20.0,<3.0.0",
-    "pylocron>=0.2.0,<1.0.0",
+    "pylocron>=0.2.1,<1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR bumps the version of pylocron to 0.2.1 to get the fix for the trainer in binary classification tasks!

cf. https://github.com/frgfm/Holocron/pull/227 & https://github.com/frgfm/Holocron/pull/228

Any feedback is welcome!