### PR TITLE
fix: Fixed rexnet1_3x and rexnet1_5x and updated checkpoints

### DIFF
--- a/api/app/vision.py
+++ b/api/app/vision.py
@@ -36,8 +36,8 @@ def preprocess_image(pil_img: Image.Image) -> np.ndarray:
         the resized and normalized image of shape (1, C, H, W)
     """
 
-    # Resizing
-    img = pil_img.resize(MODEL_CFG["input_shape"][-2:], Image.BILINEAR)
+    # Resizing (PIL takes (W, H) order for resizing)
+    img = pil_img.resize(MODEL_CFG["input_shape"][-2:][::-1], Image.BILINEAR)
     # (H, W, C) --> (C, H, W)
     img = np.asarray(img).transpose((2, 0, 1)).astype(np.float32) / 255
     # Normalization

--- a/demo/app.py
+++ b/demo/app.py
@@ -31,8 +31,8 @@ def main(args):
             the resized and normalized image of shape (1, C, H, W)
         """
 
-        # Resizing
-        img = pil_img.resize(cfg["input_shape"][-2:], Image.BILINEAR)
+        # Resizing (PIL takes (W, H) order for resizing)
+        img = pil_img.resize(cfg["input_shape"][-2:][::-1], Image.BILINEAR)
         # (H, W, C) --> (C, H, W)
         img = np.asarray(img).transpose((2, 0, 1)).astype(np.float32) / 255
         # Normalization

--- a/pyrovision/datasets/utils.py
+++ b/pyrovision/datasets/utils.py
@@ -147,8 +147,7 @@ def parallel(
         list: list of function's results
     """
 
-    if num_threads is None:
-        num_threads = min(16, mp.cpu_count())
+    num_threads = num_threads if isinstance(num_threads, int) else min(16, mp.cpu_count())
     if num_threads < 2:
         if progress:
             results = list(map(func, tqdm(arr, total=len(arr), **kwargs)))

--- a/pyrovision/models/mobilenetv3.py
+++ b/pyrovision/models/mobilenetv3.py
@@ -17,12 +17,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 224, 224),
+        "resize_mode": "squish",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/mobilenet_v3_small_224-619caf97.pth",
     },
     "mobilenet_v3_large": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 224, 224),
+        "resize_mode": "squish",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/mobilenet_v3_large_224-33e1b104.pth",
     },
 }

--- a/pyrovision/models/resnet.py
+++ b/pyrovision/models/resnet.py
@@ -17,12 +17,14 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 224, 224),
+        "resize_mode": "squish",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/resnet18_224-40b9e7d9.pth",
     },
     "resnet34": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 224, 224),
+        "resize_mode": "squish",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/resnet34_224-e5dc3b01.pth",
     },
 }

--- a/pyrovision/models/rexnet.py
+++ b/pyrovision/models/rexnet.py
@@ -17,18 +17,21 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
+        "resize_mode": "pad",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_0x_256-ff0c2ca1.pth",
     },
     "rexnet1_3x": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
+        "resize_mode": "pad",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_3x_256-6445365e.pth",
     },
     "rexnet1_5x": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
+        "resize_mode": "pad",
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_5x_256-c3891115.pth",
     },
 }

--- a/pyrovision/models/rexnet.py
+++ b/pyrovision/models/rexnet.py
@@ -16,20 +16,20 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
     "rexnet1_0x": {
         **IMAGENET,
         "classes": ["Wildfire"],
-        "input_shape": (3, 224, 224),
+        "input_shape": (3, 256, 384),
         "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/rexnet1_0x_224-6822e18d.pth",
     },
     "rexnet1_3x": {
         **IMAGENET,
         "classes": ["Wildfire"],
-        "input_shape": (3, 224, 224),
-        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/rexnet1_3x_224-3c0f28c3.pth",
+        "input_shape": (3, 256, 384),
+        "url": None,
     },
     "rexnet1_5x": {
         **IMAGENET,
         "classes": ["Wildfire"],
-        "input_shape": (3, 224, 224),
-        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/rexnet1_5x_224-7f149109.pth",
+        "input_shape": (3, 256, 384),
+        "url": None,
     },
 }
 
@@ -79,7 +79,7 @@ def rexnet1_3x(pretrained: bool = False, progress: bool = True, **kwargs: Any) -
     Returns:
         torch.nn.Module: classification model
     """
-    return _rexnet(src.rexnet1_0x, "rexnet1_0x", pretrained, progress, **kwargs)
+    return _rexnet(src.rexnet1_3x, "rexnet1_3x", pretrained, progress, **kwargs)
 
 
 def rexnet1_5x(pretrained: bool = False, progress: bool = True, **kwargs: Any) -> src.ReXNet:
@@ -94,4 +94,4 @@ def rexnet1_5x(pretrained: bool = False, progress: bool = True, **kwargs: Any) -
     Returns:
         torch.nn.Module: classification model
     """
-    return _rexnet(src.rexnet1_0x, "rexnet1_0x", pretrained, progress, **kwargs)
+    return _rexnet(src.rexnet1_5x, "rexnet1_5x", pretrained, progress, **kwargs)

--- a/pyrovision/models/rexnet.py
+++ b/pyrovision/models/rexnet.py
@@ -17,19 +17,19 @@ default_cfgs: Dict[str, Dict[str, Any]] = {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
-        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/rexnet1_0x_224-6822e18d.pth",
+        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_0x_256-ff0c2ca1.pth",
     },
     "rexnet1_3x": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
-        "url": None,
+        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_3x_256-6445365e.pth",
     },
     "rexnet1_5x": {
         **IMAGENET,
         "classes": ["Wildfire"],
         "input_shape": (3, 256, 384),
-        "url": None,
+        "url": "https://github.com/pyronear/pyro-vision/releases/download/v0.2.0/rexnet1_5x_256-c3891115.pth",
     },
 }
 

--- a/references/classification/README.md
+++ b/references/classification/README.md
@@ -24,7 +24,7 @@ python references/classification/train.py --help
 You can also use freely our open-source dataset:
 
 ```bash
-python train.py path/to/dataset/folder --openfire --model rexnet1_0x --lr 1e-3 -b 16 --epochs 20 --device 0
+python references/classification/train.py path/to/dataset/folder --openfire --arch rexnet1_0x --lr 1e-3 -b 32 --grad-acc 2 --epochs 100 --device 0 --prefetch-size 512
 ```
 
 If you prefer to run this in Google Colab, we have a starter notebook for you!

--- a/references/classification/results.csv
+++ b/references/classification/results.csv
@@ -1,8 +1,8 @@
-architecture,input_shape,dataset,val_loss,err1
-rexnet1_0x,"(256, 384)",openfire,0.2234,0.0747
-rexnet1_3x,"(256, 384)",openfire,0.2257,0.0930
-rexnet1_5x,"(256, 384)",openfire,0.2013,0.0759
-mobilenet_v3_small,"(224, 224)",openfire,0.2969,0.1152
-mobilenet_v3_large,"(224, 224)",openfire,0.2692,0.0980
-resnet18,"(224, 224)",openfire,0.2566,0.0993
-resnet34,"(224, 224)",openfire,0.2838,0.1152
+architecture,input_shape,resize_mode,dataset,val_loss,err1
+rexnet1_0x,"(256, 384)",pad,openfire,0.2253,0.0747
+rexnet1_3x,"(256, 384)",pad,openfire,0.2264,0.0930
+rexnet1_5x,"(256, 384)",pad,openfire,0.2036,0.0759
+mobilenet_v3_small,"(224, 224)",squish,openfire,0.2785,0.0967
+mobilenet_v3_large,"(224, 224)",squish,openfire,0.2689,0.1077
+resnet18,"(224, 224)",squish,openfire,0.2353,0.0796
+resnet34,"(224, 224)",squish,openfire,0.2748,0.1126

--- a/references/classification/results.csv
+++ b/references/classification/results.csv
@@ -1,7 +1,7 @@
 architecture,input_shape,dataset,val_loss,err1
-rexnet1_0x,"(224, 224)",openfire,0.2456,0.0937
-rexnet1_3x,"(224, 224)",openfire,0.2343,0.0784
-rexnet1_5x,"(224, 224)",openfire,0.2445,0.1029
+rexnet1_0x,"(256, 384)",openfire,0.2234,0.0747
+rexnet1_3x,"(256, 384)",openfire,0.2257,0.0930
+rexnet1_5x,"(256, 384)",openfire,0.2013,0.0759
 mobilenet_v3_small,"(224, 224)",openfire,0.2969,0.1152
 mobilenet_v3_large,"(224, 224)",openfire,0.2692,0.0980
 resnet18,"(224, 224)",openfire,0.2566,0.0993

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -91,7 +91,7 @@ def main(args):
                 T.RandomApply([T.GaussianBlur(kernel_size=(3, 3), sigma=(0.1, 3))], p=0.5),
                 # Geometric
                 T.RandomHorizontalFlip(),
-                RandomZoomOut(target_size, scale=(0.3, 1.0), interpolation=interpolation),
+                RandomZoomOut(target_size, scale=(0.5, 1.0), interpolation=interpolation),
                 T.RandomPerspective(distortion_scale=0.2, interpolation=interpolation, p=0.8),
                 # Conversion
                 T.PILToTensor(),

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -82,6 +82,7 @@ def main(args):
 
     interpolation = InterpolationMode.BILINEAR
     target_size = (args.height, args.width)
+    resize_mode = ResizeMethod.PAD if args.resize_mode == "pad" else ResizeMethod.SQUISH
 
     train_transforms = (
         T.Compose(
@@ -106,7 +107,7 @@ def main(args):
 
     val_transforms = T.Compose(
         [
-            Resize(target_size, mode=ResizeMethod.PAD, interpolation=interpolation),
+            Resize(target_size, mode=resize_mode, interpolation=interpolation),
             T.PILToTensor(),
             T.ConvertImageDtype(torch.float32),
             normalize,
@@ -264,6 +265,7 @@ def main(args):
                 "gradient_accumulation": args.grad_acc,
                 "architecture": args.arch,
                 "input_size": target_size,
+                "resize_mode": resize_mode,
                 "prefetch_size": args.prefetch_size,
                 "optimizer": args.opt,
                 "dataset": "openfire" if args.openfire else "custom",
@@ -300,6 +302,7 @@ def get_parser():
     parser.add_argument("-j", "--workers", default=16, type=int, help="number of data loading workers")
     parser.add_argument("--height", default=256, type=int, help="image height")
     parser.add_argument("--width", default=384, type=int, help="image width")
+    parser.add_argument("--resize-mode", default="pad", type=str, help="resize mode")
     parser.add_argument(
         "--prefetch-size", default=None, type=int, help="prefetched images will be resized to lower RAM usage"
     )

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -234,6 +234,11 @@ def main(args):
         print(trainer._eval_metrics_str(eval_metrics))
         return
 
+    if args.plot_loss:
+        print("Checking top losses")
+        trainer.plot_top_losses(IMAGENET["mean"], IMAGENET["std"])
+        return
+
     if args.find_lr:
         print("Looking for optimal LR")
         trainer.find_lr(args.freeze_until, num_it=min(len(train_loader), 100), norm_weight_decay=args.norm_wd)
@@ -258,7 +263,7 @@ def main(args):
                 "batch_size": args.batch_size,
                 "gradient_accumulation": args.grad_acc,
                 "architecture": args.arch,
-                "input_size": args.img_size,
+                "input_size": target_size,
                 "prefetch_size": args.prefetch_size,
                 "optimizer": args.opt,
                 "dataset": "openfire" if args.openfire else "custom",
@@ -309,6 +314,7 @@ def get_parser():
     parser.add_argument("--output-file", default="./checkpoint.pth", help="path where to save")
     parser.add_argument("--resume", default="", help="resume from checkpoint")
     parser.add_argument("--test-only", dest="test_only", help="Only test the model", action="store_true")
+    parser.add_argument("--plot-loss", help="Check the top losses of the model", action="store_true")
     parser.add_argument(
         "--pretrained", dest="pretrained", help="Use pre-trained models from the modelzoo", action="store_true"
     )

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -107,7 +107,8 @@ def main(args):
     val_transforms = T.Compose(
         [
             Resize(target_size, mode=ResizeMethod.PAD, interpolation=interpolation),
-            T.ToTensor(),
+            T.PILToTensor(),
+            T.ConvertImageDtype(torch.float32),
             normalize,
         ]
     )

--- a/references/classification/train.py
+++ b/references/classification/train.py
@@ -37,25 +37,30 @@ def target_transform(target):
     return target.unsqueeze(dim=0)
 
 
-def plot_samples(images, targets, num_samples=4):
+def plot_samples(images, targets, num_samples=12):
     # Unnormalize image
     nb_samples = min(num_samples, images.shape[0])
-    _, axes = plt.subplots(1, nb_samples, figsize=(20, 5))
+    num_cols = min(nb_samples, 4)
+    num_rows = int(math.ceil(nb_samples / num_cols))
+    _, axes = plt.subplots(num_rows, num_cols, figsize=(20, 5))
     for idx in range(nb_samples):
         img = images[idx]
         img *= torch.tensor(IMAGENET["std"]).view(-1, 1, 1)
         img += torch.tensor(IMAGENET["mean"]).view(-1, 1, 1)
         img = to_pil_image(img)
 
-        axes[idx].imshow(img)
-        axes[idx].axis("off")
+        _row = int(idx / num_cols)
+        _col = idx - _row * num_cols
+
+        axes[_row][_col].imshow(img)
+        axes[_row][_col].axis("off")
         _targets = targets.squeeze()
         if _targets.ndim == 1:
-            axes[idx].set_title(_targets[idx].item())
+            axes[_row][_col].set_title(_targets[idx].item())
         else:
             class_idcs = torch.where(_targets[idx] > 0)[0]
             _info = [f"{_idx.item()} ({_targets[idx, _idx]:.2f})" for _idx in class_idcs]
-            axes[idx].set_title(" ".join(_info))
+            axes[_row][_col].set_title(" ".join(_info))
 
     plt.show()
 


### PR DESCRIPTION
This PR introduces the following modifications:
- fixes building of `rexnet1_3x` and `rexnet1_5x` (they were actually building a `rexnet1_0x` because of a typo)
- adds new features to training scipt: non-square image size, resize mode, updated augmentations, improved sample plotting, added gradient accumulation option, added an option to analyze training set image sizes and added a feature of Holocron to plot samples in the training set that yielded the highest loss
- retrained all rexnets & updated checkpoints
- updated the csv with performance
- fixed the resizing in API & demo

Any feedback is welcome!